### PR TITLE
Improve calculation for scatter sphere sizes

### DIFF
--- a/glue_ar/scatter.py
+++ b/glue_ar/scatter.py
@@ -1,5 +1,5 @@
 import pyvista as pv
-from glue_ar.utils import layer_color, xyz_for_layer
+from glue_ar.utils import layer_color, xyz_bounds, xyz_for_layer
 
 
 # For the 3D scatter viewer
@@ -38,7 +38,10 @@ def scatter_layer_as_multiblock(viewer_state, layer_state,
                                 phi_resolution=8,
                                 scaled=True):
     data = xyz_for_layer(viewer_state, layer_state, scaled=scaled)
-    spheres = [pv.Sphere(center=p, radius=layer_state.size_scaling * layer_state.size / 600, phi_resolution=phi_resolution, theta_resolution=theta_resolution) for p in data]
+    bounds = xyz_bounds(viewer_state)
+    factor = max((abs(b[1] - b[0]) for b in bounds))
+    radius = layer_state.size_scaling * layer_state.size / factor
+    spheres = [pv.Sphere(center=p, radius=radius, phi_resolution=phi_resolution, theta_resolution=theta_resolution) for p in data]
     blocks = pv.MultiBlock(spheres)
     geometry = blocks.extract_geometry()
     info = {

--- a/glue_ar/tools.py
+++ b/glue_ar/tools.py
@@ -45,7 +45,7 @@ class GLScatterExportTool(Tool):
         layer_states = [layer.state for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         for layer_state in layer_states:
             layer_info = dialog.state_dictionary[layer_state.layer.label].as_dict()
-            mesh_info = scatter_layer_as_multiblock(self.viewer.state, layer_state, **layer_info)
+            mesh_info = scatter_layer_as_multiblock(self.viewer.state, layer_state, **layer_info, scaled=True)
             data = mesh_info.pop("data")
             plotter.add_mesh(data, **mesh_info)
 


### PR DESCRIPTION
This PR partially solves #10 by calculating the sphere radius based on the viewer bounds (along with the layer state), rather than using some magic number.

This works fine in the current setup, where we're always preserving the aspect ratio of the viewer space. But if we ever decide not to do this, we'll need to do a bit more - we'll either need to generate the sphere points ourselves, or grab the ones from pyvista and give them the appropriate affine transformation.