### PR TITLE
Allow specifying isosurface count in volume export

### DIFF
--- a/glue_ar/export.py
+++ b/glue_ar/export.py
@@ -152,7 +152,7 @@ def export_modelviewer(output_path, gltf_path, alt_text):
         camera-orbit="0.9677rad 1.2427rad auto"
         shadow-intensity="1"
         ar
-        ar-modes="webxr scene-viewer quick-look fallback"
+        ar-modes="webxr quick-look"
         camera-controls
         alt="{alt_text}"
     >

--- a/glue_ar/export_volume.py
+++ b/glue_ar/export_volume.py
@@ -11,3 +11,4 @@ class ARVolumeExportOptions(State):
 
     use_gaussian_filter = CallbackProperty(False)
     smoothing_iterations = CallbackProperty(0)
+    isosurface_count = CallbackProperty(5)

--- a/glue_ar/scatter.py
+++ b/glue_ar/scatter.py
@@ -124,7 +124,7 @@ def scatter_layer_as_multiblock(viewer_state, layer_state,
                          scaled=scaled)
     factor = max((abs(b[1] - b[0]) for b in bounds))
     if layer_state.size_mode == "Fixed":
-        radius = layer_state.size_scaling * sqrt((layer_state.size)) / (10 * factor)
+        radius = layer_state.size_scaling * sqrt(layer_state.size) / (10 * factor)
         spheres = [pv.Sphere(center=p, radius=radius,
                              phi_resolution=phi_resolution,
                              theta_resolution=theta_resolution) for p in data]


### PR DESCRIPTION
This PR allows specifying the number of isosurfaces to use when exporting a figure from the volume viewer.