### PR TITLE
Fix QR tool and update model-viewer HTML

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include glue_ar/js *
+recursive-include glue_ar/resources *

--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -65,7 +65,6 @@ def export_viewer(viewer_state: Vispy3DViewerState,
         export_modelviewer(mv_path, filepath, viewer_state.title)
 
 
-
 def compress_gltf_pipeline(filepath: str):
     run(["node", GLTF_PIPELINE_FILEPATH, "-i", filepath, "-o", filepath, "-d"], capture_output=True)
 

--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -1,8 +1,10 @@
 from collections import defaultdict
-from os.path import abspath, dirname, join, splitext
+from os.path import join, extsep, split, splitext
+from string import Template
 from subprocess import run
 from typing import Dict
 from glue.core.state_objects import State
+from glue.config import settings
 from glue_vispy_viewers.scatter.viewer_state import Vispy3DViewerState
 from glue_vispy_viewers.volume.layer_state import VolumeLayerState
 
@@ -10,17 +12,16 @@ from glue_vispy_viewers.volume.layer_state import VolumeLayerState
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.usd_builder import USDBuilder
-from glue_ar.utils import Bounds, BoundsWithResolution, export_label_for_layer
+from glue_ar.utils import PACKAGE_DIR, RESOURCES_DIR, Bounds, BoundsWithResolution, export_label_for_layer
 
 from typing import List, Tuple, Union
 
 
-NODE_MODULES_DIR = join(abspath(join(dirname(abspath(__file__)), "..")),
-                        "js", "node_modules")
-
+NODE_MODULES_DIR = join(PACKAGE_DIR, "js", "node_modules")
 
 GLTF_PIPELINE_FILEPATH = join(NODE_MODULES_DIR, "gltf-pipeline", "bin", "gltf-pipeline.js")
 GLTFPACK_FILEPATH = join(NODE_MODULES_DIR, "gltfpack", "cli.js")
+
 
 _BUILDERS = {
     "gltf": GLTFBuilder,
@@ -36,7 +37,8 @@ def export_viewer(viewer_state: Vispy3DViewerState,
                   state_dictionary: Dict[str, Tuple[str, State]],
                   filepath: str):
 
-    ext = splitext(filepath)[1][1:]
+    base, ext = splitext(filepath)
+    ext = ext[1:]
     builder = _BUILDERS[ext]()
     layer_groups = defaultdict(list)
     export_groups = defaultdict(list)
@@ -58,12 +60,17 @@ def export_viewer(viewer_state: Vispy3DViewerState,
 
     builder.build_and_export(filepath)
 
+    if ext in ["gltf", "glb"]:
+        mv_path = f"{base}{extsep}html"
+        export_modelviewer(mv_path, filepath, viewer_state.title)
 
-def compress_gltf_pipeline(filepath):
+
+
+def compress_gltf_pipeline(filepath: str):
     run(["node", GLTF_PIPELINE_FILEPATH, "-i", filepath, "-o", filepath, "-d"], capture_output=True)
 
 
-def compress_gltfpack(filepath):
+def compress_gltfpack(filepath: str):
     run(["node", GLTFPACK_FILEPATH, "-i", filepath, "-o", filepath], capture_output=True)
 
 
@@ -73,115 +80,32 @@ COMPRESSORS = {
 }
 
 
-def compress_gl(filepath, method="draco"):
+def compress_gl(filepath: str, method: str = "draco"):
     compressor = COMPRESSORS.get(method, None)
     if compressor is None:
         raise ValueError("Invalid compression method specified")
     compressor(filepath)
 
 
-def export_modelviewer(output_path, gltf_path, alt_text):
+def export_modelviewer(output_path: str, gltf_path: str, alt_text: str):
     mv_url = "https://ajax.googleapis.com/ajax/libs/model-viewer/3.3.0/model-viewer.min.js"
-    html = f"""
-    <html>
-        <body>
-            <script type="module" src="{mv_url}"></script>
-            <style>
-        model-viewer {{
-          width: 100%;
-          height: 100%;
-        }}
+    with open(join(RESOURCES_DIR, "model-viewer.html")) as f:
+        html_template = f.read()
+    with open(join(RESOURCES_DIR, "model-viewer.css")) as g:
+        css_template = g.read()
+    css = Template(css_template).substitute({"bg_color": settings.BACKGROUND_COLOR})
+    style = f"<style>{css}</style>"
 
-        /* This keeps child nodes hidden while the element loads */
-        :not(:defined) > * {{
-          display: none;
-        }}
-        .ar-button {{
-          background-repeat: no-repeat;
-          background-size: 20px 20px;
-          background-position: 12px 50%;
-          background-color: #fff;
-          position: absolute;
-          left: 50%;
-          transform: translateX(-50%);
-          bottom: 16px;
-          padding: 0px 16px 0px 40px;
-          font-family: Roboto Regular, Helvetica Neue, sans-serif;
-          font-size: 14px;
-          color:#4285f4;
-          height: 36px;
-          line-height: 36px;
-          border-radius: 18px;
-          border: 1px solid #DADCE0;
-        }}
-        .ar-button:active {{
-          background-color: #E8EAED;
-        }}
-        .ar-button:focus {{
-          outline: none;
-        }}
-        .ar-button:focus-visible {{
-          outline: 1px solid #4285f4;
-        }}
-        .hotspot {{
-          position: relative;
-          background: #ddd;
-          border-radius: 32px;
-          box-sizing: border-box;
-          border: 0;
-          --min-hotspot-opacity: 0.5;
-          width: 24px;
-          height: 24px;
-          padding: 8px;
-          cursor: pointer;
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
-        }}
-        .hotspot:focus {{
-          border: 4px solid rgb(0, 128, 200);
-          width: 32px;
-          height: 32px;
-          outline: none;
-        }}
-        .hotspot > * {{
-          transform: translateY(-50%);
-          opacity: 1;
-        }}
-        .hotspot:not([data-visible]) > * {{
-          pointer-events: none;
-          opacity: 0;
-          transform: translateY(calc(-50% + 4px));
-          transition: transform 0.3s, opacity 0.3s;
-        }}
-        .info {{
-          display: block;
-          position: absolute;
-          font-family: Futura, Helvetica Neue, sans-serif;
-          color: rgba(0, 0, 0, 0.8);
-          font-weight: 700;
-          font-size: 18px;
-          max-width: 128px;
-          padding: 0.5em 1em;
-          background: #ddd;
-          border-radius: 4px;
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
-          left: calc(100% + 1em);
-          top: 50%;
-        }}
-    </style>
-    <model-viewer
-        src="{gltf_path}"
-        camera-orbit="0.9677rad 1.2427rad auto"
-        shadow-intensity="1"
-        ar
-        ar-modes="webxr quick-look"
-        camera-controls
-        alt="{alt_text}"
-    >
-        <button slot="ar-button" class="ar-button">View in your space</button>
-        </model-viewer>
-        </body>
-    </html>
-    """
+    _, gltf_name = split(gltf_path)
 
-    with open(output_path, 'w') as f:
-        f.write(html)
+    substitutions = {
+        "url": mv_url,
+        "gltf_path": gltf_name,
+        "alt_text": alt_text,
+        "style": style,
+        "button_text": "View in AR",
+    }
+    html = Template(html_template).substitute(substitutions)
+
+    with open(output_path, 'w') as of:
+        of.write(html)

--- a/glue_ar/qt/qr_dialog.py
+++ b/glue_ar/qt/qr_dialog.py
@@ -20,4 +20,4 @@ class QRDialog(QDialog):
         self.ui.label_url.setText(f"<a href=\"{url}\">Open 3D view</a>")
         self.ui.label_image.setPixmap(self.pix)
         width, height = img.size
-        self.setFixedSize(width, height + 30)
+        self.setFixedSize(width, height + 60)

--- a/glue_ar/resources/model-viewer.css
+++ b/glue_ar/resources/model-viewer.css
@@ -1,0 +1,67 @@
+:root {
+  --glue-red: #eb1c24;
+}
+
+body {
+  margin: 0;
+  background-color: $bg_color;
+}
+
+model-viewer {
+  width: 100%;
+  height: 100%;
+}
+
+/* This keeps child nodes hidden while the element loads */
+:not(:defined) > * {
+  display: none;
+}
+.ar-button {
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: 12px 50%;
+  background-color: #f5c6c888;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 16px;
+  padding: 0px 16px 0px 40px;
+  font-family: Roboto Regular, Helvetica Neue, sans-serif;
+  font-size: 60pt;
+  font-weight: bold;
+  color: var(--glue-red);
+  height: 200px;
+  width: max(300px, 80%);
+  border-radius: 18px;
+  border: 5px solid var(--glue-red);
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
+.ar-button:active {
+  background-color: #E8EAED;
+}
+.ar-button:focus {
+  outline: none;
+}
+.ar-button:focus-visible {
+  outline: 1px solid #1f5ef1; 
+}
+.info {
+  display: block;
+  position: absolute;
+  font-family: Futura, Helvetica Neue, sans-serif;
+  color: rgba(0, 0, 0, 0.8);
+  font-weight: 700;
+  font-size: 18px;
+  max-width: 128px;
+  padding: 0.5em 1em;
+  background: #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+  left: calc(100% + 1em);
+  top: 50%;
+}
+

--- a/glue_ar/resources/model-viewer.html
+++ b/glue_ar/resources/model-viewer.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <script type="module" src="$url"></script>
+      $style
+  </head>
+  <body>
+    <model-viewer
+      src="$gltf_path"
+      camera-orbit="0.9677rad 1.2427rad auto"
+      shadow-intensity="1"
+      ar
+      ar-modes="webxr quick-look"
+      camera-controls
+      alt="$alt_text"
+    >
+      <button slot="ar-button" class="ar-button">
+        $button_text
+      </button>
+    </model-viewer>
+  </body>
+</html>
+

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -1,4 +1,4 @@
-import os
+from os.path import abspath, dirname, join
 from uuid import uuid4
 from glue.core import BaseData
 from glue.core.subset_group import GroupedSubset
@@ -12,7 +12,9 @@ from numpy import array, inf, isnan, ndarray
 from typing import Literal, overload, Iterable, List, Optional, Tuple, Union
 
 
-AR_ICON = os.path.abspath(os.path.join(os.path.dirname(__file__), "ar"))
+PACKAGE_DIR = dirname(abspath(__file__))
+AR_ICON = abspath(join(dirname(__file__), "ar"))
+RESOURCES_DIR = join(PACKAGE_DIR, "resources")
 
 Bounds = List[Tuple[float, float]]
 BoundsWithResolution = List[Tuple[float, float, int]]

--- a/setup.py
+++ b/setup.py
@@ -735,7 +735,7 @@ setup_args = dict(
     zip_safe=False,
     packages=find_packages(name, exclude=["js"]),
     package_data={
-        "glue_ar": ["py.typed"],
+        "glue_ar": ["py.typed", "resources/**"],
     },
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
This PR makes the following changes:
* Fix the QR tool, which was broken after #35
* Update the styling of the model-viewer HTML - in particular, the "View in AR" button is now much more prominent
    - Additionally, we now store the HTML and CSS templates for the exported model-viewer page in resource files, and combine these (with appropriate substitutions) to generate the output HTML. For convenience, this styling information is still included as a `style` tag in the HTML (that is, the export is one file). I suppose we could make this an option if we wanted to?