### PR TITLE
Add UI for Jupyter export tool

### DIFF
--- a/glue_ar/common/export_dialog_base.py
+++ b/glue_ar/common/export_dialog_base.py
@@ -79,4 +79,8 @@ class ARExportDialogBase:
             self._layer_export_states[self.state.layer][method_name] = state
         self.state_dictionary[self.state.layer] = (method_name, state)
 
+    @staticmethod
+    def display_name(prop):
+        return prop.replace("_", " ").capitalize()
+
 

--- a/glue_ar/common/export_dialog_base.py
+++ b/glue_ar/common/export_dialog_base.py
@@ -1,0 +1,82 @@
+from typing import Dict, List, Tuple
+
+from echo import delay_callback
+from glue.core.state_objects import State
+from glue.viewers.common.viewer import LayerArtist, Viewer
+from glue_vispy_viewers.scatter.layer_artist import VispyLayerArtist
+
+from glue_ar.common.export_options import ar_layer_export
+from glue_ar.common.export_state import ARExportDialogState
+from glue_ar.utils import export_label_for_layer
+
+
+class ARExportDialogBase:
+
+    def __init__(self, viewer: Viewer):
+        
+        self.viewer = viewer
+        layers = [layer for layer in self.viewer.layers if layer.enabled and layer.state.visible]
+        self.state = ARExportDialogState(layers)
+
+        self._layer_export_states: Dict[str, Dict[str, State]] = {
+            export_label_for_layer(layer): {}
+            for layer in layers
+        }
+        self.state_dictionary: Dict[str, Tuple[str, State]] = {}
+        self._initialize_dictionaries(layers)
+
+        self.state.add_callback('layer', self._on_layer_change)
+        self.state.add_callback('filetype', self._on_filetype_change)
+        self.state.add_callback('method', self._on_method_change)
+
+    def _initialize_dictionaries(self, layers: List[LayerArtist]):
+        for layer in layers:
+            method = self.state.method
+            label = export_label_for_layer(layer)
+            if label in self.state_dictionary:
+                _, state = self.state_dictionary[label]
+            else:
+                states = ar_layer_export.export_state_classes(type(layer.state))
+                state_cls = next((t[1] for t in states if t[0] == self.state.method), None)
+                if state_cls is None:
+                    method_names = ar_layer_export.method_names(type(layer.state), self.state.filetype)
+                    method = method_names[0]
+                    state_cls = next(t[1] for t in states if t[0] == method)
+                state = state_cls()
+                self.state_dictionary[label] = (method, state)
+            self._layer_export_states[label][method] = state
+
+    def _layer_for_label(self, label: str) -> VispyLayerArtist:
+        return next(layer for layer in self.state.layers if export_label_for_layer(layer) == label)
+
+
+    def _on_layer_change(self, layer_name: str):
+        layer = self._layer_for_label(layer_name)
+        layer_state_cls = type(layer.state)
+        method_names = ar_layer_export.method_names(layer_state_cls, self.state.filetype)
+        if layer_name in self.state_dictionary:
+            method, state = self.state_dictionary[layer_name]
+        else:
+            method = method_names[0]
+            state = ar_layer_export.options_class(layer_state_cls, method)()
+            self.state_dictionary[layer_name] = (method, state)
+
+        with delay_callback(self.state, 'method'):
+            self.state.method_helper.choices = method_names
+            self.state.method = method
+
+    def _on_filetype_change(self, filetype: str):
+        pass
+
+    def _on_method_change(self, method_name: str):
+        if method_name in self._layer_export_states[self.state.layer]:
+            state = self._layer_export_states[self.state.layer][method_name]
+        else:
+            layer = self._layer_for_label(self.state.layer)
+            states = ar_layer_export.export_state_classes(type(layer.state))
+            state_cls = next(t[1] for t in states if t[0] == method_name)
+            state = state_cls()
+            self._layer_export_states[self.state.layer][method_name] = state
+        self.state_dictionary[self.state.layer] = (method_name, state)
+
+

--- a/glue_ar/common/export_dialog_base.py
+++ b/glue_ar/common/export_dialog_base.py
@@ -49,6 +49,8 @@ class ARExportDialogBase:
     def _layer_for_label(self, label: str) -> VispyLayerArtist:
         return next(layer for layer in self.state.layers if export_label_for_layer(layer) == label)
 
+    def _update_layer_ui(self, state: State):
+        pass
 
     def _on_layer_change(self, layer_name: str):
         layer = self._layer_for_label(layer_name)
@@ -62,8 +64,12 @@ class ARExportDialogBase:
             self.state_dictionary[layer_name] = (method, state)
 
         with delay_callback(self.state, 'method'):
+            method_change = method != self.state.method
             self.state.method_helper.choices = method_names
             self.state.method = method
+
+        if not method_change:
+            self._update_layer_ui(state)
 
     def _on_filetype_change(self, filetype: str):
         pass

--- a/glue_ar/common/export_dialog_base.py
+++ b/glue_ar/common/export_dialog_base.py
@@ -13,7 +13,7 @@ from glue_ar.utils import export_label_for_layer
 class ARExportDialogBase:
 
     def __init__(self, viewer: Viewer):
-        
+
         self.viewer = viewer
         layers = [layer for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         self.state = ARExportDialogState(layers)
@@ -88,5 +88,3 @@ class ARExportDialogBase:
     @staticmethod
     def display_name(prop):
         return prop.replace("_", " ").capitalize()
-
-

--- a/glue_ar/common/export_options.py
+++ b/glue_ar/common/export_options.py
@@ -46,8 +46,8 @@ class ARExportLayerOptionsRegistry(DictRegistry):
         return [(name, export_state_cls) for (state_cls, name), export_state_cls in
                 self.method_state_types.items() if layer_state_cls == state_cls]
 
-    def options_class(self, state_cls, name) -> Optional[Type[State]]:
-        return self.method_state_types.get((state_cls, name), None)
+    def options_class(self, state_cls, name) -> Type[State]:
+        return self.method_state_types[(state_cls, name)]
 
     def export_spec(self, state_cls, name, extension) -> ARExportSpecification:
         return self._members[(state_cls, name, extension)]

--- a/glue_ar/common/export_options.py
+++ b/glue_ar/common/export_options.py
@@ -2,7 +2,7 @@ from glue.config import DictRegistry
 from glue.core.state_objects import State
 from glue_vispy_viewers.common.layer_state import VispyLayerState
 
-from typing import Callable, Iterable, List, Optional, Tuple, Type
+from typing import Callable, Iterable, List, Tuple, Type
 
 
 __all__ = ["ar_layer_export"]

--- a/glue_ar/common/export_state.py
+++ b/glue_ar/common/export_state.py
@@ -32,5 +32,4 @@ class ARExportDialogState(State):
 
         self.layers = layers
         self.layer_helper = ComboHelper(self, 'layer')
-        add_data_label = data_count(self.layers) > 1
-        self.layer_helper.choices = [export_label_for_layer(layer_state, add_data_label) for layer_state in layers]
+        self.layer_helper.choices = [export_label_for_layer(layer_state) for layer_state in layers]

--- a/glue_ar/common/export_state.py
+++ b/glue_ar/common/export_state.py
@@ -3,7 +3,7 @@ from glue.core.data_combo_helper import ComboHelper
 from glue.core.state_objects import State
 from glue_vispy_viewers.common.layer_state import LayerState
 
-from glue_ar.utils import data_count, export_label_for_layer
+from glue_ar.utils import export_label_for_layer
 
 from typing import Iterable
 

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -36,7 +36,7 @@ def widgets_for_property(instance: HasCallbackProperties,
         # Are the `link` conversion functions enough?
         widget = v.TextField(label=display_name)
         link((instance, property),
-             (widget, 'value'),
+             (widget, 'v_model'),
              lambda value: str(value),
              lambda text: t(text))
         return [widget]
@@ -86,6 +86,10 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         self.dialog_state = self.state
 
     def _update_layer_ui(self, state: State):
+        if self.layer_layout is not None:
+            for widget in self.layer_layout.children:
+                widget.close()
+
         widgets = []
         for property, _ in state.iter_callback_properties():
             name = self.display_name(property)

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -55,6 +55,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
     filetype_items = traitlets.List().tag(sync=True)
 
     method_items = traitlets.List().tag(sync=True)
+    method_selected = traitlets.Int().tag(sync=True)
 
     layer_layout = traitlets.Instance(DOMWidget).tag(sync=True, **widget_serialization)
 
@@ -67,6 +68,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         self.layer_layout = VBox()
         VuetifyTemplate.__init__(self)
 
+        self._on_layer_change(self.state.layer)
 
         link_glue_choices(self, self.state, 'layer')
         link_glue_choices(self, self.state, 'compression')
@@ -76,6 +78,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         self.dialog_open = display
         self.on_cancel = on_cancel
         self.on_export = on_export
+        self.dialog_state = self.state
 
     def _update_layer_ui(self, state: State):
         widgets = []

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -1,0 +1,102 @@
+import ipyvuetify as v  # noqa
+from ipyvuetify.VuetifyTemplate import VuetifyTemplate
+from ipywidgets import DOMWidget, VBox, widget_serialization
+from os.path import dirname, join
+import traitlets
+from typing import Callable, List, Optional
+
+from echo import HasCallbackProperties
+from glue.core.state_objects import State
+from glue.viewers.common.viewer import Viewer
+from glue_jupyter.link import link
+from glue_jupyter.utils import ipyvue
+from glue_jupyter.state_traitlets_helpers import GlueState
+from glue_jupyter.vuetify_helpers import link_glue_choices
+
+from glue_ar.common.export_dialog_base import ARExportDialogBase
+
+
+# We need to register our int-field component
+ipyvue.register_component_from_file( 
+    None, "int-field", join(dirname(__file__), "int_field.vue"))
+
+
+def widgets_for_property(instance: HasCallbackProperties,
+                        property: str,
+                        display_name: str) -> List[DOMWidget]:
+
+    value = getattr(instance, property)
+    t = type(value)
+    if t is bool:
+        widget = v.Checkbox(label=display_name)
+        link((instance, property), (widget, 'value'))
+        return [widget]
+    elif t in (int, float):
+        # TODO: How to do text field validation Python-side?
+        # Are the `link` conversion functions enough?
+        widget = v.TextField(label=display_name)
+        link((instance, property),
+             (widget, 'value'),
+             lambda value: str(value),
+             lambda text: t(text))
+        return [widget]
+    else:
+        return []
+
+
+class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
+
+    template_file = (__file__, "export_dialog.vue")
+    dialog_state = GlueState().tag(sync=True)
+    dialog_open = traitlets.Bool().tag(sync=True)
+
+    layer_items = traitlets.List().tag(sync=True)
+    compression_items = traitlets.List().tag(sync=True)
+    filetype_items = traitlets.List().tag(sync=True)
+
+    method_items = traitlets.List().tag(sync=True)
+
+    layer_layout = traitlets.Instance(DOMWidget).tag(sync=True, **widget_serialization)
+
+    def __init__(self,
+                 viewer: Viewer,
+                 display: Optional[bool] = False,
+                 on_cancel: Optional[Callable] = None,
+                 on_export: Optional[Callable] = None):
+        ARExportDialogBase.__init__(self, viewer=viewer)
+        self.layer_layout = VBox()
+        VuetifyTemplate.__init__(self)
+
+
+        link_glue_choices(self, self.state, 'layer')
+        link_glue_choices(self, self.state, 'compression')
+        link_glue_choices(self, self.state, 'filetype')
+        link_glue_choices(self, self.state, 'method')
+
+        self.dialog_open = display
+        self.on_cancel = on_cancel
+        self.on_export = on_export
+
+    def _update_layer_ui(self, state: State):
+        widgets = []
+        for property, _ in state.iter_callback_properties():
+            name = self.display_name(property)
+            widgets.extend(widgets_for_property(state, property, name))
+        self.layer_layout = VBox(children=widgets)
+
+    def _on_method_change(self, method_name: str):
+        super()._on_method_change(method_name)
+        state = self._layer_export_states[self.state.layer][method_name]
+        self._update_layer_ui(state)
+
+    def vue_cancel(self, *args):
+        self.state = None
+        self.state_dictionary = {}
+        self.dialog_open = False
+        if self.on_cancel:
+            self.on_cancel()
+
+    def vue_export(self, *args):
+        self.dialog_open = False
+        if self.on_export:
+            self.on_export()

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -14,6 +14,7 @@ from glue_jupyter.vuetify_helpers import link_glue_choices
 from glue_ar.common.export_dialog_base import ARExportDialogBase
 
 
+# Based on https://github.com/widgetti/ipyvuetify/issues/241
 class NumberField(v.VuetifyTemplate):
     label = traitlets.Unicode().tag(sync=True)
     value = traitlets.Unicode().tag(sync=True)
@@ -25,7 +26,7 @@ class NumberField(v.VuetifyTemplate):
         self.number_type = type
         self.label = label
         self.error_message = error_message
-    
+
     @traitlets.default("template")
     def _template(self):
         return """
@@ -43,7 +44,7 @@ class NumberField(v.VuetifyTemplate):
         self.temp_error = None
         try:
             self.number_type(value)
-        except:
+        except ValueError:
             self.temp_error = self.error_message
 
 

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -51,8 +51,13 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
     dialog_open = traitlets.Bool().tag(sync=True)
 
     layer_items = traitlets.List().tag(sync=True)
+    layer_selected = traitlets.Int().tag(sync=True)
+
     compression_items = traitlets.List().tag(sync=True)
+    compression_selected = traitlets.Int().tag(sync=True)
+
     filetype_items = traitlets.List().tag(sync=True)
+    filetype_selected = traitlets.Int().tag(sync=True)
 
     method_items = traitlets.List().tag(sync=True)
     method_selected = traitlets.Int().tag(sync=True)
@@ -92,14 +97,14 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         state = self._layer_export_states[self.state.layer][method_name]
         self._update_layer_ui(state)
 
-    def vue_cancel(self, *args):
+    def vue_cancel_dialog(self, *args):
         self.state = None
         self.state_dictionary = {}
         self.dialog_open = False
         if self.on_cancel:
             self.on_cancel()
 
-    def vue_export(self, *args):
+    def vue_export_viewer(self, *args):
         self.dialog_open = False
         if self.on_export:
             self.on_export()

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -94,7 +94,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         for property, _ in state.iter_callback_properties():
             name = self.display_name(property)
             widgets.extend(widgets_for_property(state, property, name))
-        self.layer_layout = VBox(children=widgets)
+        self.layer_layout = v.Container(children=widgets, px_0=True, py_0=True)
 
     def _on_method_change(self, method_name: str):
         super()._on_method_change(method_name)

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -32,9 +32,7 @@ def widgets_for_property(instance: HasCallbackProperties,
         link((instance, property), (widget, 'value'))
         return [widget]
     elif t in (int, float):
-        # TODO: How to do text field validation Python-side?
-        # Are the `link` conversion functions enough?
-        widget = v.TextField(label=display_name)
+        widget = v.TextField(label=display_name, type="number")
         link((instance, property),
              (widget, 'v_model'),
              lambda value: str(value),

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -1,24 +1,28 @@
 <template>
   <v-dialog
     v-model="dialog_open"
+    width="500px"
   >
     <v-card>
       <v-card-title>
         Export 3D File
       </v-card-title>
       <v-container>
+        <!--
         <v-list
           :items="layer_items"
-          v-model:selected="state.layer"
-        />
+          v-model:selected="dialog_state.layer"
+        ></v-list>
+        -->
         <v-text>Layer Options</v-text>
         <jupyter-widget :widget="layer_layout"/>
         <v-select
           v-if="method_items.length > 1"
           label="Export method"
           :items="method_items"
-          v-model="state.method"
+          v-model="method_selected"
         />
+        <!--
         <v-divider></v-divider>
         <v-text>File Options</v-text>
         <v-select
@@ -37,6 +41,7 @@
           <v-btn @click="cancel">Cancel</v-btn>
           <v-btn @click="export">Export</v-btn>
         </v-row>
+    -->
       </v-container>
     </v-card>
   </v-dialog>

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -13,7 +13,9 @@
             v-model="layer_selected"
           >
             <v-list-item
-              v-for="layer in layer_items"
+              v-for="(layer, index) in layer_items"
+              :key="index"
+              :value="index"
             >
               {{ layer.text }}
             </v-list-item>
@@ -48,3 +50,14 @@
     </v-card>
   </v-dialog>
 </template>
+
+
+<script>
+export default {
+  watch: {
+    layer_selected(value) {
+      console.log(`layer_selected is ${value}`);
+    }
+  }
+}
+</script>

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -8,6 +8,7 @@
         Export 3D File
       </v-card-title>
       <v-container>
+        <h3>Layers</h3>
         <v-list>
           <v-list-item-group
             v-model="layer_selected"
@@ -21,7 +22,7 @@
             </v-list-item>
           </v-list-item-group>
         </v-list>
-        <v-text>Layer Options</v-text>
+        <h3>Layer Options</h3>
         <jupyter-widget :widget="layer_layout"/>
         <v-select
           v-if="method_items.length > 1"
@@ -29,8 +30,7 @@
           :items="method_items"
           v-model="method_selected"
         />
-        <v-divider></v-divider>
-        <v-text>File Options</v-text>
+        <h3>File Options</h3>
         <v-select
           label="Filetype"
           :items="filetype_items"
@@ -43,8 +43,8 @@
         />
         <v-row>
           <v-spacer></v-spacer>
-          <v-btn @click="cancel_dialog">Cancel</v-btn>
-          <v-btn @click="export_viewer">Export</v-btn>
+          <v-btn class="mx-2" color="error" @click="cancel_dialog">Cancel</v-btn>
+          <v-btn class="mx-2" color="success" @click="export_viewer">Export</v-btn>
         </v-row>
       </v-container>
     </v-card>

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -50,14 +50,3 @@
     </v-card>
   </v-dialog>
 </template>
-
-
-<script>
-export default {
-  watch: {
-    layer_selected(value) {
-      console.log(`layer_selected is ${value}`);
-    }
-  }
-}
-</script>

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -8,12 +8,17 @@
         Export 3D File
       </v-card-title>
       <v-container>
-        <!--
-        <v-list
-          :items="layer_items"
-          v-model:selected="dialog_state.layer"
-        ></v-list>
-        -->
+        <v-list>
+          <v-list-item-group
+            v-model="layer_selected"
+          >
+            <v-list-item
+              v-for="layer in layer_items"
+            >
+              {{ layer.text }}
+            </v-list-item>
+          </v-list-item-group>
+        </v-list>
         <v-text>Layer Options</v-text>
         <jupyter-widget :widget="layer_layout"/>
         <v-select
@@ -22,26 +27,23 @@
           :items="method_items"
           v-model="method_selected"
         />
-        <!--
         <v-divider></v-divider>
         <v-text>File Options</v-text>
         <v-select
           label="Filetype"
           :items="filetype_items"
-          v-model="state.filetype"
+          v-model="filetype_selected"
         />
         <v-select
-          v-if="['glB', 'glTF'].includes(state.filetype)"
           label="Compression method"
           :items="compression_items"
-          v-model="state.compression"
+          v-model="compression_selected"
         />
         <v-row>
           <v-spacer></v-spacer>
-          <v-btn @click="cancel">Cancel</v-btn>
-          <v-btn @click="export">Export</v-btn>
+          <v-btn @click="cancel_dialog">Cancel</v-btn>
+          <v-btn @click="export_viewer">Export</v-btn>
         </v-row>
-    -->
       </v-container>
     </v-card>
   </v-dialog>

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -1,0 +1,43 @@
+<template>
+  <v-dialog
+    v-model="dialog_open"
+  >
+    <v-card>
+      <v-card-title>
+        Export 3D File
+      </v-card-title>
+      <v-container>
+        <v-list
+          :items="layer_items"
+          v-model:selected="state.layer"
+        />
+        <v-text>Layer Options</v-text>
+        <jupyter-widget :widget="layer_layout"/>
+        <v-select
+          v-if="method_items.length > 1"
+          label="Export method"
+          :items="method_items"
+          v-model="state.method"
+        />
+        <v-divider></v-divider>
+        <v-text>File Options</v-text>
+        <v-select
+          label="Filetype"
+          :items="filetype_items"
+          v-model="state.filetype"
+        />
+        <v-select
+          v-if="['glB', 'glTF'].includes(state.filetype)"
+          label="Compression method"
+          :items="compression_items"
+          v-model="state.compression"
+        />
+        <v-row>
+          <v-spacer></v-spacer>
+          <v-btn @click="cancel">Cancel</v-btn>
+          <v-btn @click="export">Export</v-btn>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -32,11 +32,16 @@ class JupyterARExportTool(Tool):
     def activate(self):
 
         done = False
+        def on_cancel():
+            nonlocal done
+            done = True
         self.export_dialog = JupyterARExportDialog(
                                 viewer=self.viewer,
                                 display=True,
-                                on_cancel=lambda: done = True,
-                                on_submit=lambda: self._open_file_dialog)
+                                on_cancel=on_cancel,
+                                on_export=self._open_file_dialog)
+        with self.viewer.output_widget:
+            display(self.export_dialog)
 
     def _open_file_dialog(self):
         file_chooser = FileChooser(getcwd())

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -10,12 +10,14 @@ from glue_vispy_viewers.volume.qt.volume_viewer import VispyVolumeViewerMixin
 
 from glue_ar.common.export import export_viewer
 from glue_ar.common.export_options import ar_layer_export
+from glue_ar.jupyter.export_dialog import JupyterARExportDialog
 from glue_ar.utils import AR_ICON, export_label_for_layer, xyz_bounds
 
 import ipyvuetify as v  # noqa
-from ipywidgets import HBox, Layout  # noqa
+from ipywidgets import HBox, Layout, VBox  # noqa
 from IPython.display import display  # noqa
 from ipyfilechooser import FileChooser
+
 
 __all__ = ["JupyterARExportTool"]
 
@@ -28,6 +30,15 @@ class JupyterARExportTool(Tool):
     tool_tip = "Export the current view to a 3D file"
 
     def activate(self):
+
+        done = False
+        self.export_dialog = JupyterARExportDialog(
+                                viewer=self.viewer,
+                                display=True,
+                                on_cancel=lambda: done = True,
+                                on_submit=lambda: self._open_file_dialog)
+
+    def _open_file_dialog(self):
         file_chooser = FileChooser(getcwd())
         ok_btn = v.Btn(color='success', disabled=True, children=['Ok'])
         close_btn = v.Btn(color='error', children=['Close'])
@@ -93,27 +104,11 @@ class JupyterARExportTool(Tool):
             self.save_figure(filepath)
             self.viewer.output_widget.clear_output()
 
-    def _state_dictionary(self,
-                          layers: Iterable[LayerState],
-                          filetype: str) -> Dict[str, Tuple[str, State]]:
-        state_dict = {}
-        for layer in layers:
-            label = export_label_for_layer(layer)
-            layer_state_cls = type(layer.state)
-            states = ar_layer_export.export_state_classes(layer_state_cls)
-            method_names = ar_layer_export.method_names(layer_state_cls, filetype)
-            method = method_names[0]
-            state_cls = next(t[1] for t in states if t[0] == method)
-            state = state_cls()
-            state_dict[label] = (method, state)
-
-        return state_dict
-
     def save_figure(self, filepath):
         bounds = xyz_bounds(self.viewer.state, with_resolution=isinstance(self.viewer, VispyVolumeViewerMixin))
         layers = [layer for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         filetype = splitext(filepath)[1][1:]
-        state_dict = self._state_dictionary(layers, filetype)
+        state_dict = self.export_dialog.state_dictionary
         export_viewer(viewer_state=self.viewer.state,
                       layer_states=[layer.state for layer in self.viewer.layers
                                     if layer.enabled and layer.state.visible],

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -1,17 +1,13 @@
 from os import getcwd
-from os.path import exists, splitext
-from typing import Dict, Iterable, Tuple
+from os.path import exists
 
 from glue.config import viewer_tool
-from glue.core.state_objects import State
-from glue.viewers.common.state import LayerState
 from glue.viewers.common.tool import Tool
 from glue_vispy_viewers.volume.qt.volume_viewer import VispyVolumeViewerMixin
 
 from glue_ar.common.export import export_viewer
-from glue_ar.common.export_options import ar_layer_export
 from glue_ar.jupyter.export_dialog import JupyterARExportDialog
-from glue_ar.utils import AR_ICON, export_label_for_layer, xyz_bounds
+from glue_ar.utils import AR_ICON, xyz_bounds
 
 import ipyvuetify as v  # noqa
 from ipywidgets import HBox, Layout # noqa
@@ -32,9 +28,11 @@ class JupyterARExportTool(Tool):
     def activate(self):
 
         done = False
+
         def on_cancel():
             nonlocal done
             done = True
+
         self.export_dialog = JupyterARExportDialog(
                                 viewer=self.viewer,
                                 display=True,

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -62,8 +62,6 @@ class JupyterARExportTool(Tool):
         )
 
         def on_ok_click(button, event, data):
-            with self.viewer.output_widget:
-                print("On ok click", file_chooser.selected)
             self.maybe_save_figure(file_chooser.selected)
 
         def on_close_click(button, event, data):
@@ -82,8 +80,6 @@ class JupyterARExportTool(Tool):
             display(dialog)
 
     def maybe_save_figure(self, filepath):
-        with self.viewer.output_widget:
-            print("Maybe save figure")
         if exists(filepath):
             yes_btn = v.Btn(color='success', children=["Yes"])
             no_btn = v.Btn(color='error', children=["No"])
@@ -118,10 +114,6 @@ class JupyterARExportTool(Tool):
         bounds = xyz_bounds(self.viewer.state, with_resolution=isinstance(self.viewer, VispyVolumeViewerMixin))
         layer_states = [layer.state for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         state_dict = self.export_dialog.state_dictionary
-        with self.viewer.output_widget:
-            print("About to export")
-            print(bounds)
-            print(layer_states)
         export_viewer(viewer_state=self.viewer.state,
                       layer_states=layer_states,
                       bounds=bounds,

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -35,13 +35,13 @@ class JupyterARExportTool(Tool):
         def on_cancel():
             nonlocal done
             done = True
-        self.export_dialog = JupyterARExportDialog(
+        export_dialog = JupyterARExportDialog(
                                 viewer=self.viewer,
                                 display=True,
                                 on_cancel=on_cancel,
                                 on_export=self._open_file_dialog)
         with self.viewer.output_widget:
-            display(self.export_dialog)
+            display(export_dialog)
 
     def _open_file_dialog(self):
         file_chooser = FileChooser(getcwd())

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -1,30 +1,20 @@
 import os
-from typing import Dict, List, Tuple
+from typing import List
 
 from echo import HasCallbackProperties
 from echo.qt import autoconnect_callbacks_to_qt, connect_checkable_button, connect_float_text
 from glue.core.state_objects import State
 from glue_qt.utils import load_ui
-from glue_vispy_viewers.common.vispy_data_viewer import delay_callback
-from glue_vispy_viewers.scatter.layer_artist import VispyLayerArtist
 from glue_ar.common.export_dialog_base import ARExportDialogBase
-
-from glue_ar.common.export_options import ar_layer_export
-from glue_ar.common.export_state import ARExportDialogState
-from glue_ar.utils import export_label_for_layer
 
 from qtpy.QtWidgets import QCheckBox, QDialog, QHBoxLayout, QLabel, QLayout, QLineEdit, QWidget
 from qtpy.QtGui import QIntValidator, QDoubleValidator
 
 
-__all__ = ['ARExportDialog']
+__all__ = ['QtARExportDialog']
 
 
-def display_name(prop):
-    return prop.replace("_", " ").capitalize()
-
-
-class ARExportDialog(ARExportDialogBase, QDialog):
+class QtARExportDialog(ARExportDialogBase, QDialog):
 
     def __init__(self, parent=None, viewer=None):
 
@@ -51,7 +41,7 @@ class ARExportDialog(ARExportDialogBase, QDialog):
             widget.setText(display_name)
             self._layer_connections.append(connect_checkable_button(instance, property, widget))
             return [widget]
-        elif t in [int, float]:
+        elif t in (int, float):
             label = QLabel()
             prompt = f"{display_name}:"
             label.setText(prompt)
@@ -90,7 +80,7 @@ class ARExportDialog(ARExportDialogBase, QDialog):
         self._layer_connections = []
         for property in state.callback_properties():
             row = QHBoxLayout()
-            name = display_name(property)
+            name = self.display_name(property)
             widgets = self._widgets_for_property(state, property, name)
             for widget in widgets:
                 row.addWidget(widget)

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -92,6 +92,6 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
         self.ui.label_compression_message.setVisible(gl)
 
     def _on_method_change(self, method_name: str):
-        super()._on_filetype_change(method_name)
+        super()._on_method_change(method_name)
         state = self._layer_export_states[self.state.layer][method_name]
         self._update_layer_ui(state)

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -73,8 +73,6 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
         multiple_methods = len(self.state.method_helper.choices) > 1
         self.ui.label_method.setVisible(multiple_methods)
         self.ui.combosel_method.setVisible(multiple_methods)
-        state = self.state_dictionary[layer_name][1]
-        self._update_layer_ui(state)
 
     def _update_layer_ui(self, state: State):
         self._clear_layer_layout()

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -7,6 +7,7 @@ from glue.core.state_objects import State
 from glue_qt.utils import load_ui
 from glue_vispy_viewers.common.vispy_data_viewer import delay_callback
 from glue_vispy_viewers.scatter.layer_artist import VispyLayerArtist
+from glue_ar.common.export_dialog_base import ARExportDialogBase
 
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.export_state import ARExportDialogState
@@ -23,52 +24,20 @@ def display_name(prop):
     return prop.replace("_", " ").capitalize()
 
 
-class ARExportDialog(QDialog):
+class ARExportDialog(ARExportDialogBase, QDialog):
 
     def __init__(self, parent=None, viewer=None):
 
-        super(ARExportDialog, self).__init__(parent=parent)
+        ARExportDialogBase.__init__(self, viewer=viewer)
+        QDialog.__init__(self, parent=parent)
 
-        self.viewer = viewer
-        layers = [layer for layer in self.viewer.layers if layer.enabled and layer.state.visible]
-        self.state = ARExportDialogState(layers)
         self.ui = load_ui('export_dialog.ui', self, directory=os.path.dirname(__file__))
-
-        self._layer_export_states: Dict[str, Dict[str, State]] = {
-            export_label_for_layer(layer): {}
-            for layer in layers
-        }
-
-        self.state_dictionary: Dict[str, Tuple[str, State]] = {}
-        self._on_layer_change(self.state.layer)
-        for layer in layers:
-            method = self.state.method
-            label = export_label_for_layer(layer)
-            if label in self.state_dictionary:
-                _, state = self.state_dictionary[label]
-            else:
-                states = ar_layer_export.export_state_classes(type(layer.state))
-                state_cls = next((t[1] for t in states if t[0] == self.state.method), None)
-                if state_cls is None:
-                    method_names = ar_layer_export.method_names(type(layer.state), self.state.filetype)
-                    method = method_names[0]
-                    state_cls = next(t[1] for t in states if t[0] == method)
-                state = state_cls()
-                self.state_dictionary[label] = (method, state)
-            self._layer_export_states[label][method] = state
 
         self._connections = autoconnect_callbacks_to_qt(self.state, self.ui)
         self._layer_connections = []
 
         self.ui.button_cancel.clicked.connect(self.reject)
         self.ui.button_ok.clicked.connect(self.accept)
-
-        self.state.add_callback('layer', self._on_layer_change)
-        self.state.add_callback('filetype', self._on_filetype_change)
-        self.state.add_callback('method', self._on_method_change)
-
-    def _layer_for_label(self, label: str) -> VispyLayerArtist:
-        return next(layer for layer in self.state.layers if export_label_for_layer(layer) == label)
 
     def _widgets_for_property(self,
                               instance: HasCallbackProperties,
@@ -109,25 +78,12 @@ class ARExportDialog(QDialog):
         self._clear_layout(self.ui.layer_layout)
 
     def _on_layer_change(self, layer_name: str):
-        layer = self._layer_for_label(layer_name)
-        layer_state_cls = type(layer.state)
-        method_names = ar_layer_export.method_names(layer_state_cls, self.state.filetype)
-        if layer_name in self.state_dictionary:
-            method, state = self.state_dictionary[layer_name]
-        else:
-            method = method_names[0]
-            state = ar_layer_export.options_class(layer_state_cls, method)()
-            self.state_dictionary[layer_name] = (method, state)
-
-        with delay_callback(self.state, 'method'):
-            self.state.method_helper.choices = method_names
-            method_change = method != self.state.method
-            self.state.method = method
-        multiple_methods = len(method_names) > 1
+        super()._on_layer_change(layer_name)
+        multiple_methods = len(self.state.method_helper.choices) > 1
         self.ui.label_method.setVisible(multiple_methods)
         self.ui.combosel_method.setVisible(multiple_methods)
-        if not method_change:
-            self._update_layer_ui(state)
+        state = self.state_dictionary[layer_name][1]
+        self._update_layer_ui(state)
 
     def _update_layer_ui(self, state: State):
         self._clear_layer_layout()
@@ -141,18 +97,12 @@ class ARExportDialog(QDialog):
             self.ui.layer_layout.addRow(row)
 
     def _on_filetype_change(self, filetype: str):
+        super()._on_filetype_change(filetype)
         gl = filetype.lower() in ["gltf", "glb"]
         self.ui.combosel_compression.setVisible(gl)
         self.ui.label_compression_message.setVisible(gl)
 
     def _on_method_change(self, method_name: str):
-        if method_name in self._layer_export_states[self.state.layer]:
-            state = self._layer_export_states[self.state.layer][method_name]
-        else:
-            layer = self._layer_for_label(self.state.layer)
-            states = ar_layer_export.export_state_classes(type(layer.state))
-            state_cls = next(t[1] for t in states if t[0] == method_name)
-            state = state_cls()
-            self._layer_export_states[self.state.layer][method_name] = state
-        self.state_dictionary[self.state.layer] = (method_name, state)
+        super()._on_filetype_change(method_name)
+        state = self._layer_export_states[self.state.layer][method_name]
         self._update_layer_ui(state)

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -25,6 +25,7 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
 
         self._connections = autoconnect_callbacks_to_qt(self.state, self.ui)
         self._layer_connections = []
+        self._on_layer_change(self.state.layer)
 
         self.ui.button_cancel.clicked.connect(self.reject)
         self.ui.button_ok.clicked.connect(self.accept)

--- a/glue_ar/qt/export_dialog.ui
+++ b/glue_ar/qt/export_dialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Export 3D Volume</string>
+   <string>Export 3D File</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
    <item row="4" column="0" colspan="2">

--- a/glue_ar/qt/export_tool.py
+++ b/glue_ar/qt/export_tool.py
@@ -10,7 +10,7 @@ from glue_qt.utils.threading import Worker
 
 from glue_ar.utils import AR_ICON, xyz_bounds
 from glue_ar.common.export import export_viewer
-from glue_ar.qt.export_dialog import ARExportDialog
+from glue_ar.qt.export_dialog import QtARExportDialog
 from glue_ar.qt.exporting_dialog import ExportingDialog
 
 
@@ -42,7 +42,7 @@ class QtARExportTool(Tool):
 
     def activate(self):
 
-        dialog = ARExportDialog(parent=self.viewer, viewer=self.viewer)
+        dialog = QtARExportDialog(parent=self.viewer, viewer=self.viewer)
         result = dialog.exec_()
         if result == QDialog.Rejected:
             return


### PR DESCRIPTION
This PR adds a UI for the Jupyter export tool. The layout is essentially the same the as the Qt export dialog, since the same options are available. Because of this, I've factored all of the frontend-agnostic pieces into a base export dialog class that we now inherit from for both the Qt and Jupyter versions.

The Jupyter dialog is an ipyvuetify widget created using a Vue template, with the exception of the layer-specific pieces which are created Python-side and inserted into the template via a `jupyter-widget`. I originally had these as ipyvuetify `TextField`s, but ultimately ended up creating small custom Vuetify templates in order to make validation rules work.