### PR TITLE
Test point locations of glTF scatter export

### DIFF
--- a/glue_ar/common/tests/gltf_helpers.py
+++ b/glue_ar/common/tests/gltf_helpers.py
@@ -56,10 +56,11 @@ def unpack_points(gltf: GLTF,
     current_point = []
     for value in iter_unpack(format, data):
         if len(current_point) < 3:
-            current_point.append(value)
+            current_point.append(value[0])
         else:
             unpacked.append(tuple(current_point))
-            current_point = [value]
+            current_point = [value[0]]
+
     unpacked.append(tuple(current_point))
 
     return unpacked

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -125,7 +125,7 @@ class TestScatterGLTF:
 
         # Unpack the center of each sphere mesh matches the
         # corresponding data point
-        tolerance = 1e-5
+        tolerance = 1e-7
         for index, mesh in enumerate(model.meshes):
             buffer_view = model.bufferViews[mesh.primitives[0].attributes.POSITION]
             points = unpack_vertices(gltf, model.buffers[0], buffer_view)


### PR DESCRIPTION
This PR makes a small improvement to the test suite by testing that the sphere meshes in an exported scatter glTF are located in the correct places for the data. We should add the same bit of testing logic for USD as well in the future.