### PR TITLE
Add support for ipyvolume scatter viewer

### DIFF
--- a/glue_ar/__init__.py
+++ b/glue_ar/__init__.py
@@ -42,10 +42,16 @@ def setup_qt():
 
 def setup_jupyter():
     from .jupyter.export_tool import JupyterARExportTool  # noqa
-    from glue_vispy_viewers.scatter.jupyter import JupyterVispyScatterViewer
-    from glue_vispy_viewers.volume.jupyter import JupyterVispyVolumeViewer
-    JupyterVispyScatterViewer.tools = [t for t in JupyterVispyScatterViewer.tools] + ["save:ar_jupyter"]
-    JupyterVispyVolumeViewer.tools = [t for t in JupyterVispyVolumeViewer.tools] + ["save:ar_jupyter"]
+    try:
+        from glue_vispy_viewers.scatter.jupyter import JupyterVispyScatterViewer
+        from glue_vispy_viewers.volume.jupyter import JupyterVispyVolumeViewer
+        JupyterVispyScatterViewer.tools = [t for t in JupyterVispyScatterViewer.tools] + ["save:ar_jupyter"]
+        JupyterVispyVolumeViewer.tools = [t for t in JupyterVispyVolumeViewer.tools] + ["save:ar_jupyter"]
+    except ImportError:
+        pass
+
+    from glue_jupyter.ipyvolume.scatter import IpyvolumeScatterView
+    IpyvolumeScatterView.tools = [t for t in IpyvolumeScatterView.tools] + ["save:ar_jupyter"]
 
 
 def setup():

--- a/glue_ar/common/__init__.py
+++ b/glue_ar/common/__init__.py
@@ -2,5 +2,5 @@ from .marching_cubes import add_isosurface_layer_gltf, add_isosurface_layer_usd 
 from .scatter_gltf import add_scatter_layer_gltf  # noqa: F401
 from .scatter_usd import add_scatter_layer_usd  # noqa: F401
 from .voxels import add_voxel_layers_gltf, add_voxel_layers_usd  # noqa: F401
-from .scatter_export_options import ARScatterExportOptions  # noqa: F401
+from .scatter_export_options import ARVispyScatterExportOptions  # noqa: F401
 from .volume_export_options import ARIsosurfaceExportOptions, ARVoxelExportOptions  # noqa: F401

--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -3,7 +3,7 @@ from inspect import getfullargspec
 from os.path import extsep, join, split, splitext
 from string import Template
 from subprocess import run
-from typing import Dict
+from typing import Dict, Optional
 from glue.core.state_objects import State
 from glue.config import settings
 from glue_vispy_viewers.scatter.viewer_state import Vispy3DViewerState
@@ -36,7 +36,8 @@ def export_viewer(viewer_state: Vispy3DViewerState,
                   layer_states: List[VolumeLayerState],
                   bounds: Union[Bounds, BoundsWithResolution],
                   state_dictionary: Dict[str, Tuple[str, State]],
-                  filepath: str):
+                  filepath: str,
+                  compression: Optional[str]):
 
     base, ext = splitext(filepath)
     ext = ext[1:]
@@ -64,7 +65,9 @@ def export_viewer(viewer_state: Vispy3DViewerState,
 
     builder.build_and_export(filepath)
 
-    if ext in ["gltf", "glb"]:
+    if ext in ("gltf", "glb"):
+        if compression != "None":
+            compress_gl(filepath)
         mv_path = f"{base}{extsep}html"
         export_modelviewer(mv_path, filepath, viewer_state.title)
 

--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -66,8 +66,8 @@ def export_viewer(viewer_state: Vispy3DViewerState,
     builder.build_and_export(filepath)
 
     if ext in ("gltf", "glb"):
-        if compression != "None":
-            compress_gl(filepath)
+        if (compression is not None) and (compression != "None"):
+            compress_gl(filepath, method=compression)
         mv_path = f"{base}{extsep}html"
         export_modelviewer(mv_path, filepath, viewer_state.title)
 
@@ -87,7 +87,7 @@ COMPRESSORS = {
 
 
 def compress_gl(filepath: str, method: str = "draco"):
-    compressor = COMPRESSORS.get(method, None)
+    compressor = COMPRESSORS.get(method.lower(), None)
     if compressor is None:
         raise ValueError("Invalid compression method specified")
     compressor(filepath)

--- a/glue_ar/common/export_options.py
+++ b/glue_ar/common/export_options.py
@@ -1,6 +1,6 @@
 from glue.config import DictRegistry
 from glue.core.state_objects import State
-from glue_vispy_viewers.common.layer_state import VispyLayerState
+from glue.viewers.common.state import LayerState
 
 from typing import Callable, Iterable, List, Tuple, Type
 
@@ -26,7 +26,7 @@ class ARExportLayerOptionsRegistry(DictRegistry):
         self.method_state_types = {}
 
     def add(self,
-            layer_state_cls: Type[VispyLayerState],
+            layer_state_cls: Type[LayerState],
             name: str,
             layer_options_state: Type[State],
             extensions: Iterable[str],
@@ -58,7 +58,7 @@ class ARExportLayerOptionsRegistry(DictRegistry):
                 if state_cls == layer_state_cls and ext == extension]
 
     def __call__(self,
-                 layer_state_cls: Type[VispyLayerState],
+                 layer_state_cls: Type[LayerState],
                  name: str,
                  layer_options_state: Type[State],
                  extensions: Iterable[str],

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -106,12 +106,12 @@ def box_points_getter(center: Point, size: float) -> List[Point]:
 
 IPYVOLUME_TRIANGLE_GETTERS: Dict[str, Callable] = {
     "box": rectangular_prism_triangulation,
-    "sphere": partial(sphere_triangles, theta_resolution=12, phi_resolution=12),
+    "sphere": partial(sphere_triangles, theta_resolution=13, phi_resolution=13),
     "diamond": partial(sphere_triangles, theta_resolution=3, phi_resolution=3),
 }
 
 IPYVOLUME_POINTS_GETTERS: Dict[str, PointsGetter] = {
     "box": box_points_getter,
-    "sphere": sphere_points_getter(theta_resolution=12, phi_resolution=12),
+    "sphere": sphere_points_getter(theta_resolution=13, phi_resolution=13),
     "diamond": sphere_points_getter(theta_resolution=3, phi_resolution=3),
 }

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -1,3 +1,4 @@
+from types import NoneType
 from typing import Union
 
 
@@ -5,7 +6,7 @@ from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 try:
     from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
 except ImportError:
-    Scatter3DLayerState = ScatterLayerState
+    Scatter3DLayerState = NoneType
 
 ScatterLayerState3D = Union[ScatterLayerState, Scatter3DLayerState]
 

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -1,20 +1,57 @@
+from functools import partial
+from math import sqrt
+from numpy import clip, isfinite, isnan, ndarray, ones
 from types import NoneType
-from typing import Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 
+from glue.utils import ensure_numerical
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 try:
     from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
 except ImportError:
     Scatter3DLayerState = NoneType
 
+from glue_ar.common.shapes import rectangular_prism_points, rectangular_prism_triangulation, sphere_points, sphere_triangles
+from glue_ar.utils import Bounds, Viewer3DState, mask_for_bounds
+
 ScatterLayerState3D = Union[ScatterLayerState, Scatter3DLayerState]
+
+Point = Tuple[float, float, float]
+FullPointsGetter = Callable[[ScatterLayerState3D, Bounds, ndarray, Point, float], List[Point]]
+PointsGetter = Callable[[Point, float], List[Point]]
 
 VECTOR_OFFSETS = {
     'tail': 0.5,
     'middle': 0,
     'tip': -0.5,
 }
+
+def scatter_layer_mask(
+        viewer_state: Viewer3DState,
+        layer_state: ScatterLayerState3D,
+        bounds: Bounds,
+        clip_to_bounds: bool = True) -> ndarray:
+
+    if clip_to_bounds:
+        mask = mask_for_bounds(viewer_state, layer_state, bounds)
+    else:
+        mask = None
+
+    vispy_layer_state = isinstance(layer_state, ScatterLayerState)
+    fixed_size = layer_state.size_mode == "Fixed"
+    cmap_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
+    fixed_color = getattr(layer_state, cmap_mode_attr, "Fixed") == "Fixed"
+    size_attr = "size_attribute" if vispy_layer_state else "size_att"
+    if not fixed_size:
+        size_mask = isfinite(layer_state.layer[getattr(layer_state, size_attr)])
+        mask = size_mask if mask is None else (mask & size_mask)
+    cmap_attr = "cmap_attribute" if vispy_layer_state else "cmap_att"
+    if not fixed_color:
+        color_mask = isfinite(layer_state.layer[getattr(layer_state, cmap_attr)])
+        mask = color_mask if mask is None else (mask & color_mask)
+
+    return mask
 
 
 def radius_for_scatter_layer(layer_state: ScatterLayerState3D) -> float:
@@ -26,3 +63,53 @@ def radius_for_scatter_layer(layer_state: ScatterLayerState3D) -> float:
     # across one edge of the cube.
     # Hence we take the size of the vispy cube for scatter purposes to be 480
     return min(layer_state.size_scaling * layer_state.size, 30) / 480
+
+
+def sizes_for_layer(layer_state: ScatterLayerState3D,
+                    bounds: Bounds,
+                    mask: ndarray) -> Optional[ndarray]:
+    factor = max((abs(b[1] - b[0]) for b in bounds))
+    vispy_layer_state = isinstance(layer_state, ScatterLayerState)
+    if not vispy_layer_state:
+        factor *= 2
+
+    # We calculate this even if we aren't using fixed size as we might also use this for vectors
+    fixed_size = layer_state.size_mode == "Fixed"
+    if fixed_size:
+        return None
+    else:
+        # The specific size calculation is taken from the scatter layer artist
+        size_attr = "size_attribute" if vispy_layer_state else "size_att"
+        size_data = ensure_numerical(layer_state.layer[getattr(layer_state, size_attr)][mask].ravel())
+        size_data = clip(size_data, layer_state.size_vmin, layer_state.size_vmax)
+        if layer_state.size_vmax == layer_state.size_vmin:
+            sizes = sqrt(ones(size_data.shape) * 10)
+        else:
+            sizes = sqrt(((size_data - layer_state.size_vmin) /
+                         (layer_state.size_vmax - layer_state.size_vmin)))
+        sizes *= (layer_state.size_scaling / (2 * factor))
+        sizes[isnan(sizes)] = 0.
+
+    return sizes
+
+
+def sphere_points_getter(theta_resolution: int,
+                         phi_resolution: int) -> PointsGetter:
+
+    return partial(sphere_points, theta_resolution=theta_resolution, phi_resolution=phi_resolution)
+
+
+def box_points_getter(center: Point, size: float) -> List[Point]:
+    return rectangular_prism_points(center=center, sides=[size, size, size])
+
+IPYVOLUME_TRIANGLE_GETTERS: Dict[str, Callable] = {
+    "box": rectangular_prism_triangulation,
+    "sphere": partial(sphere_triangles, theta_resolution=12, phi_resolution=12),
+    "diamond": partial(sphere_triangles, theta_resolution=3, phi_resolution=3),
+}
+
+IPYVOLUME_POINTS_GETTERS: Dict[str, PointsGetter] = {
+    "box": box_points_getter,
+    "sphere": sphere_points_getter(theta_resolution=12, phi_resolution=12),
+    "diamond": sphere_points_getter(theta_resolution=3, phi_resolution=3),
+}

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -111,10 +111,12 @@ IPYVOLUME_TRIANGLE_GETTERS: Dict[str, Callable] = {
     "box": rectangular_prism_triangulation,
     "sphere": partial(sphere_triangles, theta_resolution=13, phi_resolution=13),
     "diamond": partial(sphere_triangles, theta_resolution=3, phi_resolution=3),
+    "circle_2d": partial(sphere_triangles, theta_resolution=13, phi_resolution=13),
 }
 
 IPYVOLUME_POINTS_GETTERS: Dict[str, PointsGetter] = {
     "box": box_points_getter,
     "sphere": sphere_points_getter(theta_resolution=13, phi_resolution=13),
     "diamond": sphere_points_getter(theta_resolution=3, phi_resolution=3),
+    "circle_2d": sphere_points_getter(theta_resolution=13, phi_resolution=13),
 }

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -1,6 +1,9 @@
 from functools import partial
 from numpy import clip, isfinite, isnan, ndarray, ones, sqrt
-from types import NoneType
+try:
+    from types import NoneType
+except ImportError:
+    NoneType = type(None)
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -1,5 +1,13 @@
-from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
+from typing import Union
 
+
+from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
+try:
+    from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
+except ImportError:
+    Scatter3DLayerState = ScatterLayerState
+
+ScatterLayerState3D = Union[ScatterLayerState, Scatter3DLayerState]
 
 VECTOR_OFFSETS = {
     'tail': 0.5,
@@ -8,7 +16,7 @@ VECTOR_OFFSETS = {
 }
 
 
-def radius_for_scatter_layer(layer_state: ScatterLayerState) -> float:
+def radius_for_scatter_layer(layer_state: ScatterLayerState3D) -> float:
     # This feels like a bit of a magic calculation, and it kind of is.
     # The motivation is as follows:
     # 30 is the largest size that we use in the vispy viewer - if the sizing of

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -11,7 +11,8 @@ try:
 except ImportError:
     Scatter3DLayerState = NoneType
 
-from glue_ar.common.shapes import rectangular_prism_points, rectangular_prism_triangulation, sphere_points, sphere_triangles
+from glue_ar.common.shapes import rectangular_prism_points, rectangular_prism_triangulation, \
+                                  sphere_points, sphere_triangles
 from glue_ar.utils import Bounds, Viewer3DState, mask_for_bounds
 
 ScatterLayerState3D = Union[ScatterLayerState, Scatter3DLayerState]
@@ -25,6 +26,7 @@ VECTOR_OFFSETS = {
     'middle': 0,
     'tip': -0.5,
 }
+
 
 def scatter_layer_mask(
         viewer_state: Viewer3DState,
@@ -65,8 +67,8 @@ def radius_for_scatter_layer(layer_state: ScatterLayerState3D) -> float:
 
 
 def sizes_for_scatter_layer(layer_state: ScatterLayerState3D,
-                    bounds: Bounds,
-                    mask: ndarray) -> Optional[ndarray]:
+                            bounds: Bounds,
+                            mask: ndarray) -> Optional[ndarray]:
     factor = max((abs(b[1] - b[0]) for b in bounds))
     vispy_layer_state = isinstance(layer_state, ScatterLayerState)
     if not vispy_layer_state:
@@ -100,6 +102,7 @@ def sphere_points_getter(theta_resolution: int,
 
 def box_points_getter(center: Point, size: float) -> List[Point]:
     return rectangular_prism_points(center=center, sides=[size, size, size])
+
 
 IPYVOLUME_TRIANGLE_GETTERS: Dict[str, Callable] = {
     "box": rectangular_prism_triangulation,

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -1,6 +1,5 @@
 from functools import partial
-from math import sqrt
-from numpy import clip, isfinite, isnan, ndarray, ones
+from numpy import clip, isfinite, isnan, ndarray, ones, sqrt
 from types import NoneType
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -65,7 +64,7 @@ def radius_for_scatter_layer(layer_state: ScatterLayerState3D) -> float:
     return min(layer_state.size_scaling * layer_state.size, 30) / 480
 
 
-def sizes_for_layer(layer_state: ScatterLayerState3D,
+def sizes_for_scatter_layer(layer_state: ScatterLayerState3D,
                     bounds: Bounds,
                     mask: ndarray) -> Optional[ndarray]:
     factor = max((abs(b[1] - b[0]) for b in bounds))

--- a/glue_ar/common/scatter_export_options.py
+++ b/glue_ar/common/scatter_export_options.py
@@ -9,3 +9,7 @@ class ARVispyScatterExportOptions(State):
 
     theta_resolution = CallbackProperty(8)
     phi_resolution = CallbackProperty(8)
+
+
+class ARIpyvolumeScatterExportOptions(State):
+    pass

--- a/glue_ar/common/scatter_export_options.py
+++ b/glue_ar/common/scatter_export_options.py
@@ -2,10 +2,10 @@ from echo import CallbackProperty
 from glue.core.state_objects import State
 
 
-__all__ = ["ARScatterExportOptions"]
+__all__ = ["ARVispyScatterExportOptions"]
 
 
-class ARScatterExportOptions(State):
+class ARVispyScatterExportOptions(State):
 
     theta_resolution = CallbackProperty(8)
     phi_resolution = CallbackProperty(8)

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -18,7 +18,7 @@ from glue_ar.utils import Viewer3DState, iterable_has_nan, hex_to_components, la
                           unique_id, xyz_bounds, xyz_for_layer, Bounds
 from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.scatter import Scatter3DLayerState, ScatterLayerState3D, \
-                                   PointsGetter,  box_points_getter, IPYVOLUME_POINTS_GETTERS, IPYVOLUME_TRIANGLE_GETTERS, radius_for_scatter_layer, scatter_layer_mask, sizes_for_layer, sphere_points_getter
+                                   PointsGetter,  box_points_getter, IPYVOLUME_POINTS_GETTERS, IPYVOLUME_TRIANGLE_GETTERS, radius_for_scatter_layer, scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
 
 
 
@@ -270,7 +270,7 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
     crange = layer_state.cmap_vmax - layer_state.cmap_vmin
     uri = f"layer_{unique_id()}.bin"
 
-    sizes = sizes_for_layer(layer_state, bounds, mask)
+    sizes = sizes_for_scatter_layer(layer_state, bounds, mask)
     for i, point in enumerate(data):
 
         prev_len = len(barr)

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -9,7 +9,6 @@ from typing import List, Literal, Optional, Tuple
 
 
 from glue_ar.common.export_options import ar_layer_export
-from glue_ar.common.scatter import radius_for_scatter_layer, VECTOR_OFFSETS
 from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
 from glue_ar.common.shapes import cone_triangles, cone_points, cylinder_points, cylinder_triangles, \
                                   normalize, rectangular_prism_triangulation, sphere_triangles
@@ -18,8 +17,9 @@ from glue_ar.utils import Viewer3DState, iterable_has_nan, hex_to_components, la
                           unique_id, xyz_bounds, xyz_for_layer, Bounds
 from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.scatter import Scatter3DLayerState, ScatterLayerState3D, \
-                                   PointsGetter,  box_points_getter, IPYVOLUME_POINTS_GETTERS, IPYVOLUME_TRIANGLE_GETTERS, radius_for_scatter_layer, scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
-
+                                   PointsGetter, box_points_getter, IPYVOLUME_POINTS_GETTERS, \
+                                   IPYVOLUME_TRIANGLE_GETTERS, VECTOR_OFFSETS, radius_for_scatter_layer, \
+                                   scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
 
 
 def add_vectors_gltf(builder: GLTFBuilder,
@@ -370,7 +370,6 @@ def add_vispy_scatter_layer_gltf(builder: GLTFBuilder,
                            triangles=triangles,
                            bounds=bounds,
                            clip_to_bounds=clip_to_bounds)
-
 
 
 @ar_layer_export(Scatter3DLayerState, "Scatter", ARIpyvolumeScatterExportOptions, ("gltf", "glb"))

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -1,23 +1,30 @@
+from functools import partial
 from gltflib import AccessorType, BufferTarget, ComponentType, PrimitiveMode
 from glue.utils import ensure_numerical
+from glue_jupyter.common.state3d import ViewerState3D
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 from glue_vispy_viewers.volume.viewer_state import Vispy3DViewerState
-from numpy import array, clip, isfinite, isnan, ndarray, ones, sqrt
+from numpy import clip, isfinite, isnan, ndarray, ones, sqrt
 from numpy.linalg import norm
 
-from typing import List, Literal, Optional
+from typing import Callable, Dict, List, Literal, Optional, Tuple
 
 
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.scatter import radius_for_scatter_layer, VECTOR_OFFSETS
-from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
+from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
 from glue_ar.common.shapes import cone_triangles, cone_points, cylinder_points, cylinder_triangles, \
-                                  normalize, sphere_points, sphere_triangles
+                                  normalize, rectangular_prism_points, rectangular_prism_triangulation, sphere_points, sphere_triangles
 from glue_ar.gltf_utils import add_points_to_bytearray, add_triangles_to_bytearray, index_mins, index_maxes
 from glue_ar.utils import Viewer3DState, iterable_has_nan, hex_to_components, layer_color, mask_for_bounds, \
                           unique_id, xyz_bounds, xyz_for_layer, Bounds
 from glue_ar.common.gltf_builder import GLTFBuilder
-from glue_ar.common.scatter import ScatterLayerState3D
+from glue_ar.common.scatter import Scatter3DLayerState, ScatterLayerState3D
+
+
+Point = Tuple[float, float, float]
+FullPointsGetter = Callable[[ScatterLayerState3D, Bounds, ndarray, Point, float], List[Point]]
+PointsGetter = Callable[[Point, float], List[Point]]
 
 
 def add_vectors_gltf(builder: GLTFBuilder,
@@ -207,25 +214,21 @@ def add_error_bars_gltf(builder: GLTFBuilder,
     builder.add_file_resource(errors_bin, data=barr)
 
 
-@ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("gltf", "glb"))
-def add_scatter_layer_gltf(builder: GLTFBuilder,
-                           viewer_state: Viewer3DState,
-                           layer_state: ScatterLayerState3D,
-                           theta_resolution: int,
-                           phi_resolution: int,
-                           bounds: Bounds,
-                           clip_to_bounds: bool = True):
-    bounds = xyz_bounds(viewer_state, with_resolution=False)
+def scatter_layer_mask(
+        viewer_state: Viewer3DState,
+        layer_state: ScatterLayerState3D,
+        bounds: Bounds,
+        clip_to_bounds: bool = True) -> ndarray:
+
     if clip_to_bounds:
         mask = mask_for_bounds(viewer_state, layer_state, bounds)
     else:
         mask = None
 
     vispy_layer_state = isinstance(layer_state, ScatterLayerState)
-    color_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
-    fixed_color = getattr(layer_state, color_mode_attr, "Fixed") == "Fixed"
     fixed_size = layer_state.size_mode == "Fixed"
-
+    cmap_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
+    fixed_color = getattr(layer_state, cmap_mode_attr, "Fixed") == "Fixed"
     size_attr = "size_attribute" if vispy_layer_state else "size_att"
     if not fixed_size:
         size_mask = isfinite(layer_state.layer[getattr(layer_state, size_attr)])
@@ -235,18 +238,25 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
         color_mask = isfinite(layer_state.layer[getattr(layer_state, cmap_attr)])
         mask = color_mask if mask is None else (mask & color_mask)
 
-    data = xyz_for_layer(viewer_state, layer_state,
-                         preserve_aspect=viewer_state.native_aspect,
-                         mask=mask,
-                         scaled=True)
-    data = data[:, [1, 2, 0]]
+    return mask
+
+
+def sizes_for_layer(layer_state: ScatterLayerState3D,
+                    bounds: Bounds,
+                    mask: ndarray) -> Optional[ndarray]:
     factor = max((abs(b[1] - b[0]) for b in bounds))
+    vispy_layer_state = isinstance(layer_state, ScatterLayerState)
+    if not vispy_layer_state:
+        factor *= 2
 
     # We calculate this even if we aren't using fixed size as we might also use this for vectors
-    radius = radius_for_scatter_layer(layer_state)
-    if not fixed_size:
+    fixed_size = layer_state.size_mode == "Fixed"
+    if fixed_size:
+        return None
+    else:
         # The specific size calculation is taken from the scatter layer artist
-        size_data = ensure_numerical(layer_state.layer[layer_state.size_attribute][mask].ravel())
+        size_attr = "size_attribute" if vispy_layer_state else "size_att"
+        size_data = ensure_numerical(layer_state.layer[getattr(layer_state, size_attr)][mask].ravel())
         size_data = clip(size_data, layer_state.size_vmin, layer_state.size_vmax)
         if layer_state.size_vmax == layer_state.size_vmin:
             sizes = sqrt(ones(size_data.shape) * 10)
@@ -256,8 +266,45 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
         sizes *= (layer_state.size_scaling / (2 * factor))
         sizes[isnan(sizes)] = 0.
 
+    return sizes
+
+
+def sphere_points_getter(theta_resolution: int,
+                         phi_resolution: int) -> PointsGetter:
+
+    return partial(sphere_points, theta_resolution=theta_resolution, phi_resolution=phi_resolution)
+
+
+def box_points_getter(center: Point, size: float) -> List[Point]:
+    return rectangular_prism_points(center=center, sides=[size, size, size])
+
+
+def add_scatter_layer_gltf(builder: GLTFBuilder,
+                           viewer_state: Viewer3DState,
+                           layer_state: ScatterLayerState3D,
+                           points_getter: PointsGetter,
+                           triangles: List[Tuple[int, int, int]],
+                           bounds: Bounds,
+                           clip_to_bounds: bool = True):
+    if layer_state is None:
+        return
+
+    bounds = xyz_bounds(viewer_state, with_resolution=False)
+
+    vispy_layer_state = isinstance(layer_state, ScatterLayerState)
+    fixed_size = layer_state.size_mode == "Fixed"
+    color_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
+    fixed_color = getattr(layer_state, color_mode_attr, "Fixed") == "Fixed"
+    radius = radius_for_scatter_layer(layer_state)
+    mask = scatter_layer_mask(viewer_state, layer_state, bounds, clip_to_bounds)
+
+    data = xyz_for_layer(viewer_state, layer_state,
+                         preserve_aspect=viewer_state.native_aspect,
+                         mask=mask,
+                         scaled=True)
+    data = data[:, [1, 2, 0]]
+
     barr = bytearray()
-    triangles = sphere_triangles(theta_resolution=theta_resolution, phi_resolution=phi_resolution)
     add_triangles_to_bytearray(barr, triangles)
     triangles_len = len(barr)
     max_index = max(idx for tri in triangles for idx in tri)
@@ -287,17 +334,18 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
 
     buffer = builder.buffer_count
     cmap = layer_state.cmap
+    cmap_attr = "cmap_attribute" if vispy_layer_state else "cmap_att"
     cmap_att = getattr(layer_state, cmap_attr)
     cmap_vals = layer_state.layer[cmap_att][mask]
     crange = layer_state.cmap_vmax - layer_state.cmap_vmin
     uri = f"layer_{unique_id()}.bin"
+
+    sizes = sizes_for_layer(layer_state, bounds, mask)
     for i, point in enumerate(data):
 
         prev_len = len(barr)
-        r = radius if fixed_size else sizes[i]
-        pts = sphere_points(center=point, radius=r,
-                            theta_resolution=theta_resolution,
-                            phi_resolution=phi_resolution)
+        size = radius if fixed_size else sizes[i]
+        pts = points_getter(point, size)
         add_points_to_bytearray(barr, pts)
         point_mins = index_mins(pts)
         point_maxes = index_maxes(pts)
@@ -371,3 +419,57 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
         )
 
 
+@ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("gltf", "glb"))
+def add_vispy_scatter_layer_gltf(builder: GLTFBuilder,
+                                 viewer_state: Vispy3DViewerState,
+                                 layer_state: ScatterLayerState,
+                                 options: ARVispyScatterExportOptions,
+                                 bounds: Bounds,
+                                 clip_to_bounds: bool = True):
+
+    triangles = sphere_triangles(theta_resolution=options.theta_resolution,
+                                 phi_resolution=options.phi_resolution)
+
+    points_getter = sphere_points_getter(theta_resolution=options.theta_resolution,
+                                         phi_resolution=options.phi_resolution)
+
+    add_scatter_layer_gltf(builder=builder,
+                           viewer_state=viewer_state,
+                           layer_state=layer_state,
+                           points_getter=points_getter,
+                           triangles=triangles,
+                           bounds=bounds,
+                           clip_to_bounds=clip_to_bounds)
+
+ipyvolume_triangle_getters: Dict[str, Callable] = {
+    "box": rectangular_prism_triangulation,
+    "sphere": partial(sphere_triangles, theta_resolution=12, phi_resolution=12),
+    "diamond": partial(sphere_triangles, theta_resolution=3, phi_resolution=3),
+}
+
+ipyvolume_points_getters: Dict[str, PointsGetter] = {
+    "box": box_points_getter,
+    "sphere": sphere_points_getter(theta_resolution=12, phi_resolution=12),
+    "diamond": sphere_points_getter(theta_resolution=3, phi_resolution=3),
+}
+
+@ar_layer_export(Scatter3DLayerState, "Scatter", ARIpyvolumeScatterExportOptions, ("gltf", "glb"))
+def add_ipyvolume_scatter_layer_gltf(builder: GLTFBuilder,
+                                     viewer_state: ViewerState3D,
+                                     layer_state: Scatter3DLayerState,
+                                     options: ARIpyvolumeScatterExportOptions,
+                                     bounds: Bounds,
+                                     clip_to_bounds: bool = True):
+    # TODO: What to do for circle2d?
+    geometry = str(layer_state.geo)
+    triangle_getter = ipyvolume_triangle_getters.get(geometry, rectangular_prism_triangulation)
+    triangles = triangle_getter()
+    points_getter = ipyvolume_points_getters.get(geometry, box_points_getter)
+
+    add_scatter_layer_gltf(builder=builder,
+                           viewer_state=viewer_state,
+                           layer_state=layer_state,
+                           points_getter=points_getter,
+                           triangles=triangles,
+                           bounds=bounds,
+                           clip_to_bounds=clip_to_bounds)

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -1,21 +1,22 @@
 from typing import List, Optional, Tuple
 
-from glue.utils import ensure_numerical
 from glue_jupyter.common.state3d import ViewerState3D
 from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
-from glue_vispy_viewers.scatter.viewer_state import Vispy3DScatterViewerState, Vispy3DViewerState
-from numpy import array, clip, isfinite, isnan, ndarray, ones, sqrt
+from glue_vispy_viewers.scatter.viewer_state import Vispy3DViewerState
+from numpy import array, ndarray
 from numpy.linalg import norm
 
 from glue_ar.common.export_options import ar_layer_export
-from glue_ar.common.scatter import IPYVOLUME_POINTS_GETTERS, IPYVOLUME_TRIANGLE_GETTERS, PointsGetter, ScatterLayerState3D, box_points_getter, radius_for_scatter_layer, VECTOR_OFFSETS, scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
+from glue_ar.common.scatter import IPYVOLUME_POINTS_GETTERS, IPYVOLUME_TRIANGLE_GETTERS, VECTOR_OFFSETS, PointsGetter, \
+                                   ScatterLayerState3D, box_points_getter, radius_for_scatter_layer, \
+                                   scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
 from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
 from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.shapes import cone_triangles, cone_points, cylinder_points, cylinder_triangles, \
-                                  normalize, rectangular_prism_triangulation, sphere_points, sphere_triangles
+                                  normalize, rectangular_prism_triangulation, sphere_triangles
 from glue_ar.utils import Viewer3DState, export_label_for_layer, iterable_has_nan, hex_to_components, \
-                          layer_color, mask_for_bounds, xyz_for_layer, Bounds
+                          layer_color, xyz_for_layer, Bounds
 from glue_ar.usd_utils import material_for_color
 
 
@@ -180,7 +181,7 @@ def add_scatter_layer_usd(
             colors=colors if not fixed_color else None,
             mask=mask,
         )
-        
+
 
 @ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("usdc", "usda"))
 def add_vispy_scatter_layer_usd(builder: USDBuilder,

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -8,7 +8,7 @@ from numpy.linalg import norm
 
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.scatter import radius_for_scatter_layer, VECTOR_OFFSETS
-from glue_ar.common.scatter_export_options import ARScatterExportOptions
+from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
 from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.shapes import cone_triangles, cone_points, cylinder_points, cylinder_triangles, \
                                   normalize, sphere_points, sphere_triangles
@@ -81,12 +81,12 @@ def add_vectors_usd(builder: USDBuilder,
             builder.add_mesh(tip_points, tip_triangles, color=color, opacity=layer_state.alpha)
 
 
-@ar_layer_export(ScatterLayerState, "Scatter", ARScatterExportOptions, ("usdc", "usda"))
+@ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("usdc", "usda"))
 def add_scatter_layer_usd(
     builder: USDBuilder,
     viewer_state: Vispy3DScatterViewerState,
     layer_state: ScatterLayerState,
-    options: ARScatterExportOptions,
+    options: ARVispyScatterExportOptions,
     bounds: Bounds,
     clip_to_bounds: bool = True,
 ):

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -1,25 +1,27 @@
 from typing import List, Optional, Tuple
 
 from glue.utils import ensure_numerical
+from glue_jupyter.common.state3d import ViewerState3D
+from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
-from glue_vispy_viewers.scatter.viewer_state import Vispy3DScatterViewerState
+from glue_vispy_viewers.scatter.viewer_state import Vispy3DScatterViewerState, Vispy3DViewerState
 from numpy import array, clip, isfinite, isnan, ndarray, ones, sqrt
 from numpy.linalg import norm
 
 from glue_ar.common.export_options import ar_layer_export
-from glue_ar.common.scatter import radius_for_scatter_layer, VECTOR_OFFSETS
-from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
+from glue_ar.common.scatter import IPYVOLUME_POINTS_GETTERS, IPYVOLUME_TRIANGLE_GETTERS, PointsGetter, ScatterLayerState3D, box_points_getter, radius_for_scatter_layer, VECTOR_OFFSETS, scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
+from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
 from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.shapes import cone_triangles, cone_points, cylinder_points, cylinder_triangles, \
-                                  normalize, sphere_points, sphere_triangles
-from glue_ar.utils import export_label_for_layer, iterable_has_nan, hex_to_components, \
+                                  normalize, rectangular_prism_triangulation, sphere_points, sphere_triangles
+from glue_ar.utils import Viewer3DState, export_label_for_layer, iterable_has_nan, hex_to_components, \
                           layer_color, mask_for_bounds, xyz_for_layer, Bounds
 from glue_ar.usd_utils import material_for_color
 
 
 def add_vectors_usd(builder: USDBuilder,
-                    viewer_state: Vispy3DScatterViewerState,
-                    layer_state: ScatterLayerState,
+                    viewer_state: Viewer3DState,
+                    layer_state: ScatterLayerState3D,
                     data: ndarray,
                     bounds: Bounds,
                     tip_height: float,
@@ -30,7 +32,10 @@ def add_vectors_usd(builder: USDBuilder,
                     colors: Optional[List[Tuple[int, int, int]]] = None,
                     mask: Optional[ndarray] = None):
 
-    atts = [layer_state.vx_attribute, layer_state.vy_attribute, layer_state.vz_attribute]
+    if isinstance(layer_state, ScatterLayerState):
+        atts = [layer_state.vx_attribute, layer_state.vy_attribute, layer_state.vz_attribute]
+    else:
+        atts = [layer_state.vx_att, layer_state.vy_att, layer_state.vz_att]
     vector_data = [layer_state.layer[att].ravel()[mask] for att in atts]
 
     if viewer_state.native_aspect:
@@ -81,64 +86,40 @@ def add_vectors_usd(builder: USDBuilder,
             builder.add_mesh(tip_points, tip_triangles, color=color, opacity=layer_state.alpha)
 
 
-@ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("usdc", "usda"))
 def add_scatter_layer_usd(
     builder: USDBuilder,
-    viewer_state: Vispy3DScatterViewerState,
-    layer_state: ScatterLayerState,
-    options: ARVispyScatterExportOptions,
+    viewer_state: Viewer3DState,
+    layer_state: ScatterLayerState3D,
+    points_getter: PointsGetter,
+    triangles: List[Tuple[int, int, int]],
     bounds: Bounds,
     clip_to_bounds: bool = True,
 ):
 
-    theta_resolution = options.theta_resolution
-    phi_resolution = options.phi_resolution
-    if clip_to_bounds:
-        mask = mask_for_bounds(viewer_state, layer_state, bounds)
-    else:
-        mask = None
-
+    vispy_layer_state = isinstance(layer_state, ScatterLayerState)
     fixed_size = layer_state.size_mode == "Fixed"
-    fixed_color = layer_state.color_mode == "Fixed"
+    color_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
+    fixed_color = getattr(layer_state, color_mode_attr, "Fixed") == "Fixed"
 
     identifier = export_label_for_layer(layer_state).replace(" ", "_")
 
-    if not fixed_size:
-        size_mask = isfinite(layer_state.layer[layer_state.size_attribute])
-        mask = size_mask if mask is None else (mask & size_mask)
-    if not fixed_color:
-        color_mask = isfinite(layer_state.layer[layer_state.cmap_attribute])
-        mask = color_mask if mask is None else (mask & color_mask)
-
+    mask = scatter_layer_mask(viewer_state, layer_state, bounds, clip_to_bounds)
     data = xyz_for_layer(viewer_state, layer_state,
                          preserve_aspect=viewer_state.native_aspect,
                          mask=mask,
                          scaled=True)
     data = data[:, [1, 2, 0]]
-    factor = max((abs(b[1] - b[0]) for b in bounds))
     color = layer_color(layer_state)
     color_components = tuple(hex_to_components(color))
 
     # We calculate this even if we aren't using fixed size as we might also use this for vectors
     radius = radius_for_scatter_layer(layer_state)
-    # TODO: Remove the fixed_size condition
-    if not fixed_size:
-        # The specific size calculation is taken from the scatter layer artist
-        size_data = ensure_numerical(layer_state.layer[layer_state.size_attribute][mask].ravel())
-        size_data = clip(size_data, layer_state.size_vmin, layer_state.size_vmax)
-        if layer_state.size_vmax == layer_state.size_vmin:
-            sizes = sqrt(ones(size_data.shape) * 10)
-        else:
-            sizes = sqrt(((size_data - layer_state.size_vmin) /
-                         (layer_state.size_vmax - layer_state.size_vmin)))
-        sizes *= (layer_state.size_scaling / (2 * factor))
-        sizes[isnan(sizes)] = 0.
-
-    triangles = sphere_triangles(theta_resolution=theta_resolution, phi_resolution=phi_resolution)
+    sizes = sizes_for_scatter_layer(layer_state, bounds, mask)
 
     if not fixed_color:
         cmap = layer_state.cmap
-        cmap_att = layer_state.cmap_attribute
+        cmap_attr = "cmap_attribute" if vispy_layer_state else "cmap_att"
+        cmap_att = getattr(layer_state, cmap_attr)
         cmap_vals = layer_state.layer[cmap_att][mask]
         crange = layer_state.cmap_vmax - layer_state.cmap_vmin
         normalized = [max(min((cval - layer_state.cmap_vmin) / crange, 1), 0) for cval in cmap_vals]
@@ -147,14 +128,12 @@ def add_scatter_layer_usd(
     # If we're in fixed-size mode, we can reuse the same prim and translate it
     if fixed_size:
         first_point = data[0]
-        points = sphere_points(center=first_point, radius=radius,
-                               theta_resolution=theta_resolution,
-                               phi_resolution=phi_resolution)
-        sphere_mesh = builder.add_mesh(points,
-                                       triangles,
-                                       color=color_components,
-                                       opacity=layer_state.alpha,
-                                       identifier=identifier)
+        points = points_getter(first_point, radius)
+        mesh = builder.add_mesh(points,
+                                triangles,
+                                color=color_components,
+                                opacity=layer_state.alpha,
+                                identifier=identifier)
 
         for i in range(1, len(data)):
             point = data[i]
@@ -163,16 +142,14 @@ def add_scatter_layer_usd(
                 material = None
             else:
                 material = material_for_color(builder.stage, colors[i], layer_state.alpha)
-            builder.add_translated_reference(sphere_mesh,
+            builder.add_translated_reference(mesh,
                                              translation,
                                              material=material,
                                              identifier=identifier)
 
     else:
         for i, point in enumerate(data):
-            points = sphere_points(center=point, radius=sizes[i],
-                                   theta_resolution=theta_resolution,
-                                   phi_resolution=phi_resolution)
+            points = points_getter(point, sizes[i])
             color = color_components
             if not fixed_color:
                 cval = cmap_vals[i]
@@ -203,3 +180,48 @@ def add_scatter_layer_usd(
             colors=colors if not fixed_color else None,
             mask=mask,
         )
+        
+
+@ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("usdc", "usda"))
+def add_vispy_scatter_layer_usd(builder: USDBuilder,
+                                viewer_state: Vispy3DViewerState,
+                                layer_state: ScatterLayerState,
+                                options: ARVispyScatterExportOptions,
+                                bounds: Bounds,
+                                clip_to_bounds: bool = True):
+
+    triangles = sphere_triangles(theta_resolution=options.theta_resolution,
+                                 phi_resolution=options.phi_resolution)
+
+    points_getter = sphere_points_getter(theta_resolution=options.theta_resolution,
+                                         phi_resolution=options.phi_resolution)
+
+    add_scatter_layer_usd(builder=builder,
+                          viewer_state=viewer_state,
+                          layer_state=layer_state,
+                          points_getter=points_getter,
+                          triangles=triangles,
+                          bounds=bounds,
+                          clip_to_bounds=clip_to_bounds)
+
+
+@ar_layer_export(Scatter3DLayerState, "Scatter", ARIpyvolumeScatterExportOptions, ("usdc", "usda"))
+def add_ipyvolume_scatter_layer_usd(builder: USDBuilder,
+                                    viewer_state: ViewerState3D,
+                                    layer_state: Scatter3DLayerState,
+                                    options: ARIpyvolumeScatterExportOptions,
+                                    bounds: Bounds,
+                                    clip_to_bounds: bool = True):
+    # TODO: What to do for circle2d?
+    geometry = str(layer_state.geo)
+    triangle_getter = IPYVOLUME_TRIANGLE_GETTERS.get(geometry, rectangular_prism_triangulation)
+    triangles = triangle_getter()
+    points_getter = IPYVOLUME_POINTS_GETTERS.get(geometry, box_points_getter)
+
+    add_scatter_layer_usd(builder=builder,
+                          viewer_state=viewer_state,
+                          layer_state=layer_state,
+                          points_getter=points_getter,
+                          triangles=triangles,
+                          bounds=bounds,
+                          clip_to_bounds=clip_to_bounds)

--- a/glue_ar/common/shapes.py
+++ b/glue_ar/common/shapes.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-def rectangular_prism_points(center: Iterable[float], sides: Iterable[float]) -> List[Tuple[float]]:
+def rectangular_prism_points(center: Iterable[float], sides: Iterable[float]) -> List[Tuple[float, float, float]]:
     side_diffs = [(-s / 2, s / 2) for s in sides]
     diffs = product(*side_diffs)
     points = [tuple(c - d for c, d in zip(center, diff)) for diff in diffs]

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -4,10 +4,20 @@ from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer
 from itertools import product
 from math import sqrt
 from numpy import array, array_equal, nan, ones
+from os import remove
 import pytest
-from typing import cast
+from random import random, randint, seed
+from typing import cast, Dict, Tuple, Type, Union
+
+from glue.core.state_objects import State
+from glue.viewers.common.viewer import Viewer
+from glue_jupyter import JupyterApplication
+from glue_jupyter.ipyvolume.scatter import IpyvolumeScatterView
+from glue_qt.app import GlueApplication
 
 from glue_ar.common.scatter import scatter_layer_mask
+from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
+from glue_ar.utils import export_label_for_layer
 
 
 @pytest.fixture
@@ -82,3 +92,82 @@ def test_scatter_mask_bounds(scatter_mask_data, clip, size, color):
         assert array_equal(expected, mask)
     else:
         assert mask is None
+
+
+@pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
+class BaseScatterTest:
+
+    @pytest.fixture(scope='function', autouse=True)
+    def setup_method(self, app_type: str, viewer_type: str):
+
+        # Setup
+        self.app_type = app_type
+        self.viewer_type = viewer_type
+        seed(186)
+        self.n = 40
+        x1 = [random() * 5 for _ in range(self.n)]
+        y1 = [random() for _ in range(self.n)]
+        z1 = [randint(1, 30) for _ in range(self.n)]
+        self.data1 = Data(x=x1, y=y1, z=z1, label="Scatter Data 1")
+        self.data1.style.color = "#fedcba"
+        self.app = self._create_application(app_type)
+        self.app.data_collection.append(self.data1)
+        self.viewer: Viewer = self.app.new_data_viewer(self._viewer_class(viewer_type))
+        self.viewer.add_data(self.data1)
+
+        x2 = [random() * 7 for _ in range(self.n)]
+        y2 = [randint(100, 200) for _ in range(self.n)]
+        z2 = [random() for _ in range(self.n)]
+        self.data2 = Data(x=x2, y=y2, z=z2, label="Scatter Data 2")
+
+        self.viewer.state.x_att = self.data1.id['x']
+        self.viewer.state.y_att = self.data1.id['y']
+        self.viewer.state.z_att = self.data1.id['z']
+        self.state_dictionary = self._basic_state_dictionary(viewer_type)
+
+        yield
+
+        # Teardown
+        if getattr(self, "tmpfile", None) is not None:
+            self.tmpfile.close()
+            remove(self.tmpfile.name)
+        if hasattr(self.viewer, "close"):
+            self.viewer.close(warn=False)
+        self.viewer = None
+        if hasattr(self.app, 'close'):
+            self.app.close()
+        self.app = None
+
+    def _create_application(self, app_type: str) -> Union[GlueApplication, JupyterApplication]:
+        if app_type == "qt":
+            return GlueApplication()
+        elif app_type == "jupyter":
+            return JupyterApplication()
+        else:
+            raise ValueError("Application type should be either qt or jupyter")
+
+    def _viewer_class(self, viewer_type: str) -> Union[Type[VispyScatterViewer], Type[IpyvolumeScatterView]]:
+        if viewer_type == "vispy":
+            return VispyScatterViewer
+        elif viewer_type == "ipyvolume":
+            return IpyvolumeScatterView
+        else:
+            raise ValueError("Viewer type should be either vispy or ipyvolume")
+
+    def _basic_state_dictionary(self, viewer_type: str) -> Dict[str, Tuple[str, State]]:
+        if viewer_type == "vispy":
+            state_maker = lambda: ARVispyScatterExportOptions(theta_resolution=15,
+                                                              phi_resolution=15)
+        elif viewer_type == "ipyvolume":
+            state_maker = ARIpyvolumeScatterExportOptions
+        else:
+            raise ValueError("Viewer type should be either vispy or ipyvolume")
+
+        return {
+            export_label_for_layer(layer): ("Scatter", state_maker())
+            for layer in self.viewer.layers
+        }
+
+    def _export_state_class(self, viewer_type: str):
+        return ARIpyvolumeScatterExportOptions if viewer_type == "ipyvolume" else ARVispyScatterExportOptions
+

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -125,11 +125,13 @@ class BaseScatterTest:
         if getattr(self, "tmpfile", None) is not None:
             self.tmpfile.close()
             remove(self.tmpfile.name)
-        if hasattr(self.viewer, "close"):
-            self.viewer.close(warn=False)
-        self.viewer = None
-        if hasattr(self.app, 'close'):
-            self.app.close()
+        if hasattr(self, 'viewer'):
+            if hasattr(self.viewer, "close"):
+                self.viewer.close(warn=False)
+            self.viewer = None
+        if hasattr(self, 'app'):
+            if hasattr(self.app, 'close'):
+                self.app.close()
         self.app = None
 
     def _create_application(self, app_type: str) -> Union[GlueApplication, JupyterApplication]:

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -90,11 +90,12 @@ def test_scatter_mask_bounds(scatter_mask_data, clip, size, color):
         assert mask is None
 
 
-@pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
 class BaseScatterTest:
 
-    @pytest.fixture(scope="function", autouse=True)
-    def setup(self, app_type: str, viewer_type: str):
+    # We manually invoke this function in both downstream `test_basic_export` methods
+    # which is bad, but is to work around an issue with the CI on Windows.
+    # I will look for a better solution to this.
+    def basic_setup(self, app_type: str, viewer_type: str):
         self.app_type = app_type
         self.viewer_type = viewer_type
 

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -40,7 +40,7 @@ def scatter_mask_data():
                 color=color_values, size=size_values)
 
 
-# TODO: Making this a fixture caused problems the wrapped C/C++ object
+# TODO: Making this a fixture caused problems with the wrapped C/C++ object
 # defining the viewer being deleted. Can we fix that?
 def _scatter_mask_viewer(application: GlueApplication, scatter_mask_data: Data) -> VispyScatterViewer:
     application.data_collection.append(scatter_mask_data)
@@ -93,12 +93,11 @@ def test_scatter_mask_bounds(scatter_mask_data, clip, size, color):
 @pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
 class BaseScatterTest:
 
-    @pytest.fixture(scope='function', autouse=True)
-    def setup_and_teardown(self, app_type: str, viewer_type: str):
-
-        # Setup
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, app_type: str, viewer_type: str):
         self.app_type = app_type
         self.viewer_type = viewer_type
+
         seed(186)
         self.n = 40
         x1 = [random() * 5 for _ in range(self.n)]
@@ -106,9 +105,9 @@ class BaseScatterTest:
         z1 = [randint(1, 30) for _ in range(self.n)]
         self.data1 = Data(x=x1, y=y1, z=z1, label="Scatter Data 1")
         self.data1.style.color = "#fedcba"
-        self.app = self._create_application(app_type)
+        self.app = self._create_application(self.app_type)
         self.app.data_collection.append(self.data1)
-        self.viewer: Viewer = self.app.new_data_viewer(self._viewer_class(viewer_type))
+        self.viewer: Viewer = self.app.new_data_viewer(self._viewer_class(self.viewer_type))
         self.viewer.add_data(self.data1)
 
         x2 = [random() * 7 for _ in range(self.n)]
@@ -121,9 +120,7 @@ class BaseScatterTest:
         self.viewer.state.z_att = self.data1.id['z']
         self.state_dictionary = self._basic_state_dictionary(viewer_type)
 
-        yield
-
-        # Teardown
+    def teardown_method(self, method):
         if getattr(self, "tmpfile", None) is not None:
             self.tmpfile.close()
             remove(self.tmpfile.name)

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -94,7 +94,7 @@ def test_scatter_mask_bounds(scatter_mask_data, clip, size, color):
 class BaseScatterTest:
 
     @pytest.fixture(scope='function', autouse=True)
-    def setup_method(self, app_type: str, viewer_type: str):
+    def setup_and_teardown(self, app_type: str, viewer_type: str):
 
         # Setup
         self.app_type = app_type

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -1,0 +1,84 @@
+from glue.core import Data
+from glue_qt.app import GlueApplication
+from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer
+from itertools import product
+from math import sqrt
+from numpy import array, array_equal, nan, ones
+import pytest
+from typing import cast
+
+from glue_ar.common.scatter import scatter_layer_mask
+
+
+@pytest.fixture
+def scatter_mask_data():
+    x_values = range(10, 40)
+    y_values = range(130, 160)
+    z_values = range(-50, -20)
+    n = 30
+
+    color_nan_indices = (1, 5, 6, 24)
+    color_values = array([sqrt(t) for t in x_values])
+    for index in color_nan_indices:
+        color_values[index] = nan
+
+    size_nan_indices = (2, 5, 6, 11)
+    size_values = [t / n for t in x_values]
+    for index in size_nan_indices:
+        size_values[index] = nan
+    
+    return Data(x=x_values, y=y_values, z=z_values,
+                color=color_values, size=size_values)
+
+
+# TODO: Making this a fixture caused problems the wrapped C/C++ object
+# defining the viewer being deleted. Can we fix that?
+def _scatter_mask_viewer(application: GlueApplication, scatter_mask_data: Data) -> VispyScatterViewer:
+    application.data_collection.append(scatter_mask_data)
+    viewer = cast(VispyScatterViewer, application.new_data_viewer(VispyScatterViewer, data=scatter_mask_data))
+    viewer.state.x_att = scatter_mask_data.id['x']
+    viewer.state.y_att = scatter_mask_data.id['y']
+    viewer.state.z_att = scatter_mask_data.id['z']
+    viewer.state.x_min = 10
+    viewer.state.x_max = 35
+    viewer.state.y_min = 100
+    viewer.state.y_max = 150
+    viewer.state.z_min = -45
+    viewer.state.z_max = -20
+    return viewer
+
+
+@pytest.mark.parametrize("clip,size,color", product((True, False), repeat=3))
+def test_scatter_mask_bounds(scatter_mask_data, clip, size, color):
+    application = GlueApplication()
+    viewer = _scatter_mask_viewer(application, scatter_mask_data)
+    expected = ones(30).astype(bool)
+    if clip:
+        valid_x = lambda value: value >= 10 and value <= 35
+        expected_x = array([valid_x(t) for t in scatter_mask_data['x']])
+        valid_y = lambda value: value >= 100 and value <= 150 
+        expected_y = array([valid_y(t) for t in scatter_mask_data['y']])
+        valid_z = lambda value: value >= -45 and value <= -20
+        expected_z = array([valid_z(t) for t in scatter_mask_data['z']])
+        expected &= (expected_x & expected_y & expected_z)
+    if size:
+        viewer.layers[0].state.size_attribute = scatter_mask_data.id['size']
+        viewer.layers[0].state.size_mode = "Linear"
+        expected &= array([i not in (2, 5, 6, 11) for i in range(scatter_mask_data.size)])
+    if color:
+        viewer.layers[0].state.cmap_attribute = scatter_mask_data.id['color']
+        viewer.layers[0].state.color_mode = "Linear"
+        expected &= array([i not in (1, 5, 6, 24) for i in range(scatter_mask_data.size)])
+    viewer_state = viewer.state
+    bounds = [
+        (viewer_state.x_min, viewer_state.x_max),
+        (viewer_state.y_min, viewer_state.y_max),
+        (viewer_state.z_min, viewer_state.z_max)]
+    mask = scatter_layer_mask(viewer.state,
+                              viewer.layers[0].state,
+                              bounds=bounds,
+                              clip_to_bounds=clip)
+    if any((clip, size, color)):
+        assert array_equal(expected, mask)
+    else:
+        assert mask is None

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -1,4 +1,3 @@
-from sys import platform
 from tempfile import NamedTemporaryFile
 
 from gltflib import AccessorType, AlphaMode, BufferTarget, ComponentType, GLTFModel

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -2,6 +2,7 @@ from tempfile import NamedTemporaryFile
 
 from gltflib import AccessorType, AlphaMode, BufferTarget, ComponentType, GLTFModel
 from gltflib.gltf import GLTF
+import pytest
 
 from glue_ar.common.export import export_viewer
 from glue_ar.common.shapes import sphere_points_count, sphere_triangles, sphere_triangles_count
@@ -14,7 +15,9 @@ from glue_ar.utils import export_label_for_layer, hex_to_components, layers_to_e
 class TestScatterGLTF(BaseScatterTest):
 
     # TODO: How can we test the properties of compressed files?
-    def test_basic_export(self):
+    @pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
+    def test_basic_export(self, app_type, viewer_type):
+        self.basic_setup(app_type, viewer_type)
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".gltf", delete=False)
         self.tmpfile.close()

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -1,33 +1,44 @@
 from os import remove
 from random import random, randint, seed
 from tempfile import NamedTemporaryFile
+from typing import Dict, Tuple, Type, Union
 
 from gltflib import AccessorType, AlphaMode, BufferTarget, ComponentType, GLTFModel
 from gltflib.gltf import GLTF
 from glue.core import Data
+from glue.core.state_objects import State
+from glue.viewers.common.viewer import Viewer
+from glue_jupyter import JupyterApplication
+from glue_jupyter.ipyvolume.scatter import IpyvolumeScatterView
 from glue_qt.app import GlueApplication
 from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer
+import pytest
 
 from glue_ar.common.export import export_viewer
-from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
+from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
 from glue_ar.common.shapes import sphere_points_count, sphere_triangles, sphere_triangles_count
 from glue_ar.common.tests.gltf_helpers import count_indices, count_vertices, unpack_vertices
-from glue_ar.utils import export_label_for_layer, hex_to_components, mask_for_bounds, xyz_bounds, xyz_for_layer
+from glue_ar.utils import export_label_for_layer, hex_to_components, layers_to_export, mask_for_bounds, xyz_bounds, xyz_for_layer
 
 
+@pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
 class TestScatterGLTF:
 
-    def setup_method(self, method):
+    @pytest.fixture(scope='function', autouse=True)
+    def setup_and_teardown(self, app_type: str, viewer_type: str):
+
+        # Setup
         seed(1374)
-        self.n = 40
+        self.n = 80
         x1 = [random() * 5 for _ in range(self.n)]
         y1 = [random() for _ in range(self.n)]
         z1 = [randint(1, 30) for _ in range(self.n)]
         self.data1 = Data(x=x1, y=y1, z=z1, label="Scatter Data 1")
         self.data1.style.color = "#fedcba"
-        self.app = GlueApplication()
+        self.app = self._create_application(app_type)
         self.app.data_collection.append(self.data1)
-        self.viewer = self.app.new_data_viewer(VispyScatterViewer)
+        self.viewer_type = viewer_type
+        self.viewer: Viewer = self.app.new_data_viewer(self._viewer_class(viewer_type))
         self.viewer.add_data(self.data1)
 
         x2 = [random() * 7 for _ in range(self.n)]
@@ -38,29 +49,64 @@ class TestScatterGLTF:
         self.viewer.state.x_att = self.data1.id['x']
         self.viewer.state.y_att = self.data1.id['y']
         self.viewer.state.z_att = self.data1.id['z']
-        self.state_dictionary = {
-            export_label_for_layer(layer): ("Scatter", ARVispyScatterExportOptions())
-            for layer in self.viewer.layers
-        }
+        self.state_dictionary = self._basic_state_dictionary(viewer_type)
 
-    def teardown_method(self, method):
+        yield
+
+        # Teardown
         if getattr(self, "tmpfile", None) is not None:
             self.tmpfile.close()
             remove(self.tmpfile.name)
-        self.viewer.close(warn=False)
+        if hasattr(self.viewer, "close"):
+            self.viewer.close(warn=False)
         self.viewer = None
-        self.app.close()
+        if hasattr(self.app, 'close'):
+            self.app.close()
         self.app = None
 
+    def _create_application(self, app_type: str) -> Union[GlueApplication, JupyterApplication]:
+        if app_type == "qt":
+            return GlueApplication()
+        elif app_type == "jupyter":
+            return JupyterApplication()
+        else:
+            raise ValueError("Application type should be either qt or jupyter")
+
+    def _viewer_class(self, viewer_type: str) -> Union[Type[VispyScatterViewer], Type[IpyvolumeScatterView]]:
+        if viewer_type == "vispy":
+            return VispyScatterViewer
+        elif viewer_type == "ipyvolume":
+            return IpyvolumeScatterView
+        else:
+            raise ValueError("Viewer type should be either vispy or ipyvolume")
+
+    def _basic_state_dictionary(self, viewer_type: str) -> Dict[str, Tuple[str, State]]:
+        if viewer_type == "vispy":
+            state_maker = lambda: ARVispyScatterExportOptions(theta_resolution=15,
+                                                              phi_resolution=15)
+        elif viewer_type == "ipyvolume":
+            state_maker = ARIpyvolumeScatterExportOptions
+        else:
+            raise ValueError("Viewer type should be either vispy or ipyvolume")
+
+        return {
+            export_label_for_layer(layer): ("Scatter", state_maker())
+            for layer in self.viewer.layers
+        }
+
+
+    # TODO: How can we test the properties of compressed files?
     def test_basic_export(self):
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".gltf", delete=False)
         self.tmpfile.close()
+        layer_states = [layer.state for layer in layers_to_export(self.viewer)]
         export_viewer(self.viewer.state,
-                      [layer.state for layer in self.viewer.layers],
+                      layer_states=layer_states,
                       bounds=bounds,
                       state_dictionary=self.state_dictionary,
-                      filepath=self.tmpfile.name)
+                      filepath=self.tmpfile.name,
+                      compression=None)
 
         gltf: GLTF = GLTF.load(self.tmpfile.name)
         model = gltf.model
@@ -78,7 +124,8 @@ class TestScatterGLTF:
         label = export_label_for_layer(layer)
         method, options = self.state_dictionary[label]
         assert method == "Scatter"
-        assert isinstance(options, ARVispyScatterExportOptions)
+        export_state_cls = ARIpyvolumeScatterExportOptions if self.viewer_type == "ipyvolume" else ARVispyScatterExportOptions
+        assert isinstance(options, export_state_cls)
         color_components = [c / 256 for c in hex_to_components("#fedcba")] + [layer.state.alpha]
         assert material.alphaMode == AlphaMode.BLEND.value
         assert material.pbrMetallicRoughness is not None
@@ -88,8 +135,10 @@ class TestScatterGLTF:
 
         assert all(mesh.primitives[0].indices == 0 for mesh in model.meshes)
 
-        theta_resolution: int = options.theta_resolution
-        phi_resolution: int = options.phi_resolution
+        # TODO: 3 is the value for ipyvolume's diamond, which is the ipv default
+        # But we should make this more robust
+        theta_resolution: int = getattr(options, "theta_resolution", 3)
+        phi_resolution: int = getattr(options, "phi_resolution", 3)
         triangles_count = sphere_triangles_count(theta_resolution=theta_resolution,
                                                  phi_resolution=phi_resolution)
         points_count = sphere_points_count(theta_resolution=theta_resolution,

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -1,3 +1,4 @@
+from sys import platform
 from tempfile import NamedTemporaryFile
 
 from gltflib import AccessorType, AlphaMode, BufferTarget, ComponentType, GLTFModel
@@ -15,6 +16,8 @@ class TestScatterGLTF(BaseScatterTest):
 
     # TODO: How can we test the properties of compressed files?
     def test_basic_export(self):
+        if self.app_type == "jupyter" and self.viewer == "vispy" and platform == "win32":
+            return
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".gltf", delete=False)
         self.tmpfile.close()

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -4,11 +4,11 @@ from gltflib import AccessorType, AlphaMode, BufferTarget, ComponentType, GLTFMo
 from gltflib.gltf import GLTF
 
 from glue_ar.common.export import export_viewer
-from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
 from glue_ar.common.shapes import sphere_points_count, sphere_triangles, sphere_triangles_count
 from glue_ar.common.tests.gltf_helpers import count_indices, count_vertices, unpack_vertices
 from glue_ar.common.tests.test_scatter import BaseScatterTest
-from glue_ar.utils import export_label_for_layer, hex_to_components, layers_to_export, mask_for_bounds, xyz_bounds, xyz_for_layer
+from glue_ar.utils import export_label_for_layer, hex_to_components, layers_to_export, mask_for_bounds, \
+                          xyz_bounds, xyz_for_layer
 
 
 class TestScatterGLTF(BaseScatterTest):

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -9,7 +9,7 @@ from glue_qt.app import GlueApplication
 from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer
 
 from glue_ar.common.export import export_viewer
-from glue_ar.common.scatter_export_options import ARScatterExportOptions
+from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
 from glue_ar.common.shapes import sphere_points_count, sphere_triangles, sphere_triangles_count
 from glue_ar.common.tests.gltf_helpers import count_indices, count_vertices, unpack_vertices
 from glue_ar.utils import export_label_for_layer, hex_to_components, mask_for_bounds, xyz_bounds, xyz_for_layer
@@ -39,7 +39,7 @@ class TestScatterGLTF:
         self.viewer.state.y_att = self.data1.id['y']
         self.viewer.state.z_att = self.data1.id['z']
         self.state_dictionary = {
-            export_label_for_layer(layer): ("Scatter", ARScatterExportOptions())
+            export_label_for_layer(layer): ("Scatter", ARVispyScatterExportOptions())
             for layer in self.viewer.layers
         }
 
@@ -78,7 +78,7 @@ class TestScatterGLTF:
         label = export_label_for_layer(layer)
         method, options = self.state_dictionary[label]
         assert method == "Scatter"
-        assert isinstance(options, ARScatterExportOptions)
+        assert isinstance(options, ARVispyScatterExportOptions)
         color_components = [c / 256 for c in hex_to_components("#fedcba")] + [layer.state.alpha]
         assert material.alphaMode == AlphaMode.BLEND.value
         assert material.pbrMetallicRoughness is not None

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -1,3 +1,4 @@
+from sys import platform
 from tempfile import NamedTemporaryFile
 
 from gltflib import AccessorType, AlphaMode, BufferTarget, ComponentType, GLTFModel
@@ -16,7 +17,9 @@ class TestScatterGLTF(BaseScatterTest):
 
     # TODO: How can we test the properties of compressed files?
     @pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
-    def test_basic_export(self, app_type, viewer_type):
+    def test_basic_export(self, app_type: str, viewer_type: str):
+        if app_type == "jupyter" and viewer_type == "vispy" and platform == "win32":
+            return
         self.basic_setup(app_type, viewer_type)
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".gltf", delete=False)

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -16,8 +16,6 @@ class TestScatterGLTF(BaseScatterTest):
 
     # TODO: How can we test the properties of compressed files?
     def test_basic_export(self):
-        if self.app_type == "jupyter" and self.viewer == "vispy" and platform == "win32":
-            return
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".gltf", delete=False)
         self.tmpfile.close()

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -1,4 +1,3 @@
-from sys import platform
 from tempfile import NamedTemporaryFile
 
 from pxr import Sdf, Usd

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -1,97 +1,16 @@
-from os import remove
-from random import random, randint, seed
 from tempfile import NamedTemporaryFile
-from typing import Dict, Tuple, Type, Union
 
-from glue.core import Data
-from glue.core.state_objects import State
-from glue.viewers.common.viewer import Viewer
-from glue_jupyter import JupyterApplication
-from glue_jupyter.ipyvolume.scatter import IpyvolumeScatterView
-from glue_qt.app import GlueApplication
-from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer
 from pxr import Sdf, Usd
-import pytest
 
 from glue_ar.common.export import export_viewer
-from glue_ar.common.scatter import IPYVOLUME_POINTS_GETTERS, radius_for_scatter_layer
-from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
-from glue_ar.common.shapes import sphere_points, sphere_points_count, sphere_triangles_count
+from glue_ar.common.shapes import sphere_points_count, sphere_triangles_count
 from glue_ar.usd_utils import material_for_mesh
 from glue_ar.utils import export_label_for_layer, hex_to_components, iterator_count, layers_to_export, xyz_bounds
 
+from glue_ar.common.tests.test_scatter import BaseScatterTest
 
-@pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
-class TestVispyScatterUSD:
 
-    @pytest.fixture(scope='function', autouse=True)
-    def setup_method(self, app_type: str, viewer_type: str):
-
-        # Setup
-        seed(186)
-        self.n = 40
-        x1 = [random() * 5 for _ in range(self.n)]
-        y1 = [random() for _ in range(self.n)]
-        z1 = [randint(1, 30) for _ in range(self.n)]
-        self.data1 = Data(x=x1, y=y1, z=z1, label="Scatter Data 1")
-        self.data1.style.color = "#fedcba"
-        self.app = self._create_application(app_type)
-        self.app.data_collection.append(self.data1)
-        self.viewer: Viewer = self.app.new_data_viewer(self._viewer_class(viewer_type))
-        self.viewer.add_data(self.data1)
-
-        x2 = [random() * 7 for _ in range(self.n)]
-        y2 = [randint(100, 200) for _ in range(self.n)]
-        z2 = [random() for _ in range(self.n)]
-        self.data2 = Data(x=x2, y=y2, z=z2, label="Scatter Data 2")
-
-        self.viewer.state.x_att = self.data1.id['x']
-        self.viewer.state.y_att = self.data1.id['y']
-        self.viewer.state.z_att = self.data1.id['z']
-        self.state_dictionary = self._basic_state_dictionary(viewer_type)
-
-        yield
-
-        # Teardown
-        if getattr(self, "tmpfile", None) is not None:
-            self.tmpfile.close()
-            remove(self.tmpfile.name)
-        if hasattr(self.viewer, "close"):
-            self.viewer.close(warn=False)
-        self.viewer = None
-        if hasattr(self.app, 'close'):
-            self.app.close()
-        self.app = None
-
-    def _create_application(self, app_type: str) -> Union[GlueApplication, JupyterApplication]:
-        if app_type == "qt":
-            return GlueApplication()
-        elif app_type == "jupyter":
-            return JupyterApplication()
-        else:
-            raise ValueError("Application type should be either qt or jupyter")
-
-    def _viewer_class(self, viewer_type: str) -> Union[Type[VispyScatterViewer], Type[IpyvolumeScatterView]]:
-        if viewer_type == "vispy":
-            return VispyScatterViewer
-        elif viewer_type == "ipyvolume":
-            return IpyvolumeScatterView
-        else:
-            raise ValueError("Viewer type should be either vispy or ipyvolume")
-
-    def _basic_state_dictionary(self, viewer_type: str) -> Dict[str, Tuple[str, State]]:
-        if viewer_type == "vispy":
-            state_maker = lambda: ARVispyScatterExportOptions(theta_resolution=15,
-                                                              phi_resolution=15)
-        elif viewer_type == "ipyvolume":
-            state_maker = ARIpyvolumeScatterExportOptions
-        else:
-            raise ValueError("Viewer type should be either vispy or ipyvolume")
-
-        return {
-            export_label_for_layer(layer): ("Scatter", state_maker())
-            for layer in self.viewer.layers
-        }
+class TestVispyScatterUSD(BaseScatterTest):
 
     def test_basic_export(self):
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -1,22 +1,33 @@
 from os import remove
 from random import random, randint, seed
 from tempfile import NamedTemporaryFile
+from typing import Dict, Tuple, Type, Union
 
 from glue.core import Data
+from glue.core.state_objects import State
+from glue.viewers.common.viewer import Viewer
+from glue_jupyter import JupyterApplication
+from glue_jupyter.ipyvolume.scatter import IpyvolumeScatterView
 from glue_qt.app import GlueApplication
 from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer
 from pxr import Sdf, Usd
+import pytest
 
 from glue_ar.common.export import export_viewer
-from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
-from glue_ar.common.shapes import sphere_points_count, sphere_triangles_count
+from glue_ar.common.scatter import IPYVOLUME_POINTS_GETTERS, radius_for_scatter_layer
+from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
+from glue_ar.common.shapes import sphere_points, sphere_points_count, sphere_triangles_count
 from glue_ar.usd_utils import material_for_mesh
-from glue_ar.utils import export_label_for_layer, hex_to_components, iterator_count, xyz_bounds
+from glue_ar.utils import export_label_for_layer, hex_to_components, iterator_count, layers_to_export, xyz_bounds
 
 
-class TestScatterUSD:
+@pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
+class TestVispyScatterUSD:
 
-    def setup_method(self, method):
+    @pytest.fixture(scope='function', autouse=True)
+    def setup_method(self, app_type: str, viewer_type: str):
+
+        # Setup
         seed(186)
         self.n = 40
         x1 = [random() * 5 for _ in range(self.n)]
@@ -24,9 +35,9 @@ class TestScatterUSD:
         z1 = [randint(1, 30) for _ in range(self.n)]
         self.data1 = Data(x=x1, y=y1, z=z1, label="Scatter Data 1")
         self.data1.style.color = "#fedcba"
-        self.app = GlueApplication()
+        self.app = self._create_application(app_type)
         self.app.data_collection.append(self.data1)
-        self.viewer = self.app.new_data_viewer(VispyScatterViewer)
+        self.viewer: Viewer = self.app.new_data_viewer(self._viewer_class(viewer_type))
         self.viewer.add_data(self.data1)
 
         x2 = [random() * 7 for _ in range(self.n)]
@@ -37,30 +48,62 @@ class TestScatterUSD:
         self.viewer.state.x_att = self.data1.id['x']
         self.viewer.state.y_att = self.data1.id['y']
         self.viewer.state.z_att = self.data1.id['z']
-        self.state_dictionary = {
-            export_label_for_layer(layer): ("Scatter", ARVispyScatterExportOptions())
-            for layer in self.viewer.layers
-        }
+        self.state_dictionary = self._basic_state_dictionary(viewer_type)
 
-    def teardown_method(self, method):
+        yield
+
+        # Teardown
         if getattr(self, "tmpfile", None) is not None:
             self.tmpfile.close()
             remove(self.tmpfile.name)
-
-        self.viewer.close(warn=False)
+        if hasattr(self.viewer, "close"):
+            self.viewer.close(warn=False)
         self.viewer = None
-        self.app.close()
+        if hasattr(self.app, 'close'):
+            self.app.close()
         self.app = None
+
+    def _create_application(self, app_type: str) -> Union[GlueApplication, JupyterApplication]:
+        if app_type == "qt":
+            return GlueApplication()
+        elif app_type == "jupyter":
+            return JupyterApplication()
+        else:
+            raise ValueError("Application type should be either qt or jupyter")
+
+    def _viewer_class(self, viewer_type: str) -> Union[Type[VispyScatterViewer], Type[IpyvolumeScatterView]]:
+        if viewer_type == "vispy":
+            return VispyScatterViewer
+        elif viewer_type == "ipyvolume":
+            return IpyvolumeScatterView
+        else:
+            raise ValueError("Viewer type should be either vispy or ipyvolume")
+
+    def _basic_state_dictionary(self, viewer_type: str) -> Dict[str, Tuple[str, State]]:
+        if viewer_type == "vispy":
+            state_maker = lambda: ARVispyScatterExportOptions(theta_resolution=15,
+                                                              phi_resolution=15)
+        elif viewer_type == "ipyvolume":
+            state_maker = ARIpyvolumeScatterExportOptions
+        else:
+            raise ValueError("Viewer type should be either vispy or ipyvolume")
+
+        return {
+            export_label_for_layer(layer): ("Scatter", state_maker())
+            for layer in self.viewer.layers
+        }
 
     def test_basic_export(self):
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".usdc", delete=False)
         self.tmpfile.close()
+        layer_states = [layer.state for layer in layers_to_export(self.viewer)]
         export_viewer(self.viewer.state,
-                      [layer.state for layer in self.viewer.layers],
+                      layer_states=layer_states,
                       bounds=bounds,
                       state_dictionary=self.state_dictionary,
-                      filepath=self.tmpfile.name)
+                      filepath=self.tmpfile.name,
+                      compression=None)
 
         stage = Usd.Stage.Open(self.tmpfile.name)
         world = stage.GetDefaultPrim()
@@ -70,10 +113,12 @@ class TestScatterUSD:
         label = export_label_for_layer(layer.state)
         identifier = label.replace(" ", "_")
         _, options = self.state_dictionary[label]
-        sphere_pts_count = sphere_points_count(theta_resolution=options.theta_resolution,
-                                               phi_resolution=options.phi_resolution)
-        sphere_tris_count = sphere_triangles_count(theta_resolution=options.theta_resolution,
-                                                   phi_resolution=options.phi_resolution)
+
+        # The default ipyvolume geometry type is diamond
+        theta_resolution: int = getattr(options, "theta_resolution", 3)
+        phi_resolution: int = getattr(options, "phi_resolution", 3)
+        sphere_pts_count = sphere_points_count(theta_resolution=theta_resolution, phi_resolution=phi_resolution)
+        sphere_tris_count = sphere_triangles_count(theta_resolution=theta_resolution, phi_resolution=phi_resolution)
         expected_vert_cts = [3] * sphere_tris_count
 
         color_precision = 5

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -8,7 +8,7 @@ from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer
 from pxr import Sdf, Usd
 
 from glue_ar.common.export import export_viewer
-from glue_ar.common.scatter_export_options import ARScatterExportOptions
+from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
 from glue_ar.common.shapes import sphere_points_count, sphere_triangles_count
 from glue_ar.usd_utils import material_for_mesh
 from glue_ar.utils import export_label_for_layer, hex_to_components, iterator_count, xyz_bounds
@@ -38,7 +38,7 @@ class TestScatterUSD:
         self.viewer.state.y_att = self.data1.id['y']
         self.viewer.state.z_att = self.data1.id['z']
         self.state_dictionary = {
-            export_label_for_layer(layer): ("Scatter", ARScatterExportOptions())
+            export_label_for_layer(layer): ("Scatter", ARVispyScatterExportOptions())
             for layer in self.viewer.layers
         }
 

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -1,3 +1,4 @@
+from sys import platform
 from tempfile import NamedTemporaryFile
 
 from pxr import Sdf, Usd
@@ -14,8 +15,10 @@ from glue_ar.common.tests.test_scatter import BaseScatterTest
 class TestVispyScatterUSD(BaseScatterTest):
 
     @pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
-    def test_basic_export(self, app_type, viewer_type):
+    def test_basic_export(self, app_type: str, viewer_type: str):
+        if app_type == "jupyter" and viewer_type == "vispy" and platform == "win32":
         self.basic_setup(app_type, viewer_type)
+            return
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".usdc", delete=False)
         self.tmpfile.close()

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -17,8 +17,8 @@ class TestVispyScatterUSD(BaseScatterTest):
     @pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
     def test_basic_export(self, app_type: str, viewer_type: str):
         if app_type == "jupyter" and viewer_type == "vispy" and platform == "win32":
-        self.basic_setup(app_type, viewer_type)
             return
+        self.basic_setup(app_type, viewer_type)
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".usdc", delete=False)
         self.tmpfile.close()

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -1,6 +1,7 @@
 from tempfile import NamedTemporaryFile
 
 from pxr import Sdf, Usd
+import pytest
 
 from glue_ar.common.export import export_viewer
 from glue_ar.common.shapes import sphere_points_count, sphere_triangles_count
@@ -12,7 +13,9 @@ from glue_ar.common.tests.test_scatter import BaseScatterTest
 
 class TestVispyScatterUSD(BaseScatterTest):
 
-    def test_basic_export(self):
+    @pytest.mark.parametrize("app_type,viewer_type", (("qt", "vispy"), ("jupyter", "vispy"), ("jupyter", "ipyvolume")))
+    def test_basic_export(self, app_type, viewer_type):
+        self.basic_setup(app_type, viewer_type)
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".usdc", delete=False)
         self.tmpfile.close()

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -14,8 +14,6 @@ from glue_ar.common.tests.test_scatter import BaseScatterTest
 class TestVispyScatterUSD(BaseScatterTest):
 
     def test_basic_export(self):
-        if self.app_type == "jupyter" and self.viewer == "vispy" and platform == "win32":
-            return
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".usdc", delete=False)
         self.tmpfile.close()

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -1,3 +1,4 @@
+from sys import platform
 from tempfile import NamedTemporaryFile
 
 from pxr import Sdf, Usd
@@ -13,6 +14,8 @@ from glue_ar.common.tests.test_scatter import BaseScatterTest
 class TestVispyScatterUSD(BaseScatterTest):
 
     def test_basic_export(self):
+        if self.app_type == "jupyter" and self.viewer == "vispy" and platform == "win32":
+            return
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
         self.tmpfile = NamedTemporaryFile(suffix=".usdc", delete=False)
         self.tmpfile.close()

--- a/glue_ar/gltf_utils.py
+++ b/glue_ar/gltf_utils.py
@@ -17,6 +17,12 @@ __all__ = [
 ]
 
 
+GLTF_COMPRESSION_EXTENSIONS = {
+    "draco": "KHR_draco_mesh_compression",
+    "meshoptimizer": "EXT_meshopt_compression",
+}
+
+
 def slope_intercept_between(a, b):
     slope = (b[1] - a[1]) / (b[0] - a[0])
     intercept = b[1] - slope * b[0]

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -59,6 +59,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
 
     compression_items = traitlets.List().tag(sync=True)
     compression_selected = traitlets.Int().tag(sync=True)
+    show_compression = traitlets.Bool(True).tag(sync=True)
 
     filetype_items = traitlets.List().tag(sync=True)
     filetype_selected = traitlets.Int().tag(sync=True)
@@ -109,6 +110,11 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         super()._on_method_change(method_name)
         state = self._layer_export_states[self.state.layer][method_name]
         self._update_layer_ui(state)
+
+    def _on_filetype_change(self, filetype: str):
+        super()._on_filetype_change(filetype)
+        gl = filetype.lower() in ("gltf", "glb")
+        self.show_compression = gl
 
     def widgets_for_property(self,
                              instance: HasCallbackProperties,

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -67,6 +67,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
     method_selected = traitlets.Int().tag(sync=True)
 
     layer_layout = traitlets.Instance(DOMWidget).tag(sync=True, **widget_serialization)
+    has_layer_options = traitlets.Bool().tag(sync=True)
 
     def __init__(self,
                  viewer: Viewer,
@@ -102,6 +103,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
             widgets.extend(self.widgets_for_property(state, property, name))
         self.input_widgets = [w for w in widgets if isinstance(w, NumberField)]
         self.layer_layout = v.Container(children=widgets, px_0=True, py_0=True)
+        self.has_layer_options = len(self.layer_layout.children) > 0
 
     def _on_method_change(self, method_name: str):
         super()._on_method_change(method_name)

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -41,6 +41,7 @@
           v-model="filetype_selected"
         />
         <v-select
+          v-if="show_compression"
           label="Compression method"
           :items="compression_items"
           v-model="compression_selected"

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -22,7 +22,11 @@
             </v-list-item>
           </v-list-item-group>
         </v-list>
-        <h3>Layer Options</h3>
+        <h3
+          v-if="has_layer_options"
+        >
+          Layer Options
+        </h3>
         <jupyter-widget :widget="layer_layout"/>
         <v-select
           v-if="method_items.length > 1"

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -63,7 +63,7 @@ class JupyterARExportTool(Tool):
             self.maybe_save_figure(file_chooser.selected)
 
         def on_close_click(button, event, data):
-            # self.viewer.output_widget.clear_output()
+            self.viewer.output_widget.clear_output()
             dialog.close()
 
         def on_selected_change(chooser):
@@ -94,7 +94,7 @@ class JupyterARExportTool(Tool):
 
             def on_yes_click(button, event, data):
                 self.save_figure(filepath)
-                # self.viewer.output_widget.clear_output()
+                self.viewer.output_widget.clear_output()
 
             def on_no_click(button, event, data):
                 check_dialog.v_model = False
@@ -106,21 +106,15 @@ class JupyterARExportTool(Tool):
                 display(check_dialog)
         else:
             self.save_figure(filepath)
-            # self.viewer.output_widget.clear_output()
+            self.viewer.output_widget.clear_output()
 
     def save_figure(self, filepath):
         bounds = xyz_bounds(self.viewer.state, with_resolution=isinstance(self.viewer, VispyVolumeViewerMixin))
         layer_states = [layer.state for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         state_dict = self.export_dialog.state_dictionary
-        with self.viewer.output_widget:
-            try:
-                export_viewer(viewer_state=self.viewer.state,
-                              layer_states=layer_states,
-                              bounds=bounds,
-                              state_dictionary=state_dict,
-                              filepath=filepath,
-                              compression=self.export_dialog.state.compression)
-                print(state_dict)
-            except Exception as e:
-                print(e)
-
+        export_viewer(viewer_state=self.viewer.state,
+                      layer_states=layer_states,
+                      bounds=bounds,
+                      state_dictionary=state_dict,
+                      filepath=filepath,
+                      compression=self.export_dialog.state.compression)

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -63,7 +63,7 @@ class JupyterARExportTool(Tool):
             self.maybe_save_figure(file_chooser.selected)
 
         def on_close_click(button, event, data):
-            self.viewer.output_widget.clear_output()
+            # self.viewer.output_widget.clear_output()
             dialog.close()
 
         def on_selected_change(chooser):
@@ -94,7 +94,7 @@ class JupyterARExportTool(Tool):
 
             def on_yes_click(button, event, data):
                 self.save_figure(filepath)
-                self.viewer.output_widget.clear_output()
+                # self.viewer.output_widget.clear_output()
 
             def on_no_click(button, event, data):
                 check_dialog.v_model = False
@@ -106,14 +106,21 @@ class JupyterARExportTool(Tool):
                 display(check_dialog)
         else:
             self.save_figure(filepath)
-            self.viewer.output_widget.clear_output()
+            # self.viewer.output_widget.clear_output()
 
     def save_figure(self, filepath):
         bounds = xyz_bounds(self.viewer.state, with_resolution=isinstance(self.viewer, VispyVolumeViewerMixin))
         layer_states = [layer.state for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         state_dict = self.export_dialog.state_dictionary
-        export_viewer(viewer_state=self.viewer.state,
-                      layer_states=layer_states,
-                      bounds=bounds,
-                      state_dictionary=state_dict,
-                      filepath=filepath)
+        with self.viewer.output_widget:
+            try:
+                export_viewer(viewer_state=self.viewer.state,
+                              layer_states=layer_states,
+                              bounds=bounds,
+                              state_dictionary=state_dict,
+                              filepath=filepath,
+                              compression=self.export_dialog.state.compression)
+                print(state_dict)
+            except Exception as e:
+                print(e)
+

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -42,7 +42,7 @@ class JupyterARExportTool(Tool):
             display(self.export_dialog)
 
     def _open_file_dialog(self):
-        file_chooser = FileChooser(getcwd())
+        file_chooser = FileChooser(getcwd(), filter_pattern=f"*.{self.export_dialog.state.filetype}")
         ok_btn = v.Btn(color='success', disabled=True, children=['Ok'])
         close_btn = v.Btn(color='error', children=['Close'])
         dialog = v.Dialog(
@@ -63,7 +63,7 @@ class JupyterARExportTool(Tool):
             self.maybe_save_figure(file_chooser.selected)
 
         def on_close_click(button, event, data):
-            # self.viewer.output_widget.clear_output()
+            self.viewer.output_widget.clear_output()
             dialog.close()
 
         def on_selected_change(chooser):
@@ -94,7 +94,7 @@ class JupyterARExportTool(Tool):
 
             def on_yes_click(button, event, data):
                 self.save_figure(filepath)
-                # self.viewer.output_widget.clear_output()
+                self.viewer.output_widget.clear_output()
 
             def on_no_click(button, event, data):
                 check_dialog.v_model = False
@@ -106,23 +106,15 @@ class JupyterARExportTool(Tool):
                 display(check_dialog)
         else:
             self.save_figure(filepath)
-            # self.viewer.output_widget.clear_output()
+            self.viewer.output_widget.clear_output()
 
     def save_figure(self, filepath):
         bounds = xyz_bounds(self.viewer.state, with_resolution=isinstance(self.viewer, VispyVolumeViewerMixin))
         layer_states = [layer.state for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         state_dict = self.export_dialog.state_dictionary
-
-        import traceback
-        with self.viewer.output_widget:
-            try:
-                export_viewer(viewer_state=self.viewer.state,
-                              layer_states=layer_states,
-                              bounds=bounds,
-                              state_dictionary=state_dict,
-                              filepath=filepath,
-                              compression=self.export_dialog.state.compression)
-                print(state_dict)
-            except Exception:
-                print(traceback.format_exc())
-
+        export_viewer(viewer_state=self.viewer.state,
+                      layer_states=layer_states,
+                      bounds=bounds,
+                      state_dictionary=state_dict,
+                      filepath=filepath,
+                      compression=self.export_dialog.state.compression)

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -63,7 +63,7 @@ class JupyterARExportTool(Tool):
             self.maybe_save_figure(file_chooser.selected)
 
         def on_close_click(button, event, data):
-            self.viewer.output_widget.clear_output()
+            # self.viewer.output_widget.clear_output()
             dialog.close()
 
         def on_selected_change(chooser):
@@ -94,7 +94,7 @@ class JupyterARExportTool(Tool):
 
             def on_yes_click(button, event, data):
                 self.save_figure(filepath)
-                self.viewer.output_widget.clear_output()
+                # self.viewer.output_widget.clear_output()
 
             def on_no_click(button, event, data):
                 check_dialog.v_model = False
@@ -106,15 +106,23 @@ class JupyterARExportTool(Tool):
                 display(check_dialog)
         else:
             self.save_figure(filepath)
-            self.viewer.output_widget.clear_output()
+            # self.viewer.output_widget.clear_output()
 
     def save_figure(self, filepath):
         bounds = xyz_bounds(self.viewer.state, with_resolution=isinstance(self.viewer, VispyVolumeViewerMixin))
         layer_states = [layer.state for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         state_dict = self.export_dialog.state_dictionary
-        export_viewer(viewer_state=self.viewer.state,
-                      layer_states=layer_states,
-                      bounds=bounds,
-                      state_dictionary=state_dict,
-                      filepath=filepath,
-                      compression=self.export_dialog.state.compression)
+
+        import traceback
+        with self.viewer.output_widget:
+            try:
+                export_viewer(viewer_state=self.viewer.state,
+                              layer_states=layer_states,
+                              bounds=bounds,
+                              state_dictionary=state_dict,
+                              filepath=filepath,
+                              compression=self.export_dialog.state.compression)
+                print(state_dict)
+            except Exception:
+                print(traceback.format_exc())
+

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -87,7 +87,7 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
 
     def _on_filetype_change(self, filetype: str):
         super()._on_filetype_change(filetype)
-        gl = filetype.lower() in ["gltf", "glb"]
+        gl = filetype.lower() in ("gltf", "glb")
         self.ui.combosel_compression.setVisible(gl)
         self.ui.label_compression_message.setVisible(gl)
 

--- a/glue_ar/qt/export_tool.py
+++ b/glue_ar/qt/export_tool.py
@@ -64,7 +64,8 @@ class QtARExportTool(Tool):
                         layer_states=layer_states,
                         bounds=bounds,
                         state_dictionary=dialog.state_dictionary,
-                        filepath=export_path)
+                        filepath=export_path,
+                        compression=dialog.state.compression)
         exporting_dialog = ExportingDialog(parent=self.viewer, filetype=filetype)
         worker.result.connect(exporting_dialog.close)
         worker.error.connect(exporting_dialog.close)

--- a/glue_ar/qt/qr_tool.py
+++ b/glue_ar/qt/qr_tool.py
@@ -14,7 +14,7 @@ from glue_vispy_viewers.volume.volume_viewer import VispyVolumeViewerMixin
 
 from glue_ar.utils import AR_ICON, export_label_for_layer, xyz_bounds
 from glue_ar.common.export import export_modelviewer, export_viewer
-from glue_ar.common.scatter_export_options import ARScatterExportOptions
+from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
 from glue_ar.common.volume_export_options import ARIsosurfaceExportOptions
 from glue_ar.qt.qr import get_local_ip
 from glue_ar.qt.qr_dialog import QRDialog
@@ -33,7 +33,7 @@ class ARLocalQRTool(Tool):
 
     def _export_items_for_layer(self, layer: LayerState) -> Type[State]:
         if isinstance(layer, ScatterLayerState):
-            return ("Scatter", ARScatterExportOptions())
+            return ("Scatter", ARVispyScatterExportOptions())
         else:
             return ("Isosurface", ARIsosurfaceExportOptions(isosurface_count=8))
 

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -1,7 +1,6 @@
 from os.path import abspath, dirname, join
 from uuid import uuid4
-from types import NoneType
-from typing import Iterator, Literal, overload, Iterable, List, Optional, Tuple, Type, Union
+from typing import Iterator, Literal, overload, Iterable, List, Optional, Tuple, Union
 
 from glue.core import BaseData
 from glue.core.subset_group import GroupedSubset

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -1,15 +1,22 @@
 from os.path import abspath, dirname, join
 from uuid import uuid4
+from types import NoneType
+from typing import Iterator, Literal, overload, Iterable, List, Optional, Tuple, Type, Union
+
 from glue.core import BaseData
 from glue.core.subset_group import GroupedSubset
 from glue.viewers.common.state import ViewerState
 from glue.viewers.common.viewer import LayerArtist, Viewer
+
 from glue_vispy_viewers.common.layer_state import LayerState, VispyLayerState
 from glue_vispy_viewers.volume.layer_state import VolumeLayerState
 from glue_vispy_viewers.volume.viewer_state import Vispy3DViewerState
 from numpy import array, inf, isnan, ndarray
 
-from typing import Iterator, Literal, overload, Iterable, List, Optional, Tuple, Union
+try:
+    from glue_jupyter.common.state3d import ViewerState3D
+except ImportError:
+    ViewerState3D = Vispy3DViewerState
 
 
 PACKAGE_DIR = dirname(abspath(__file__))
@@ -18,6 +25,8 @@ RESOURCES_DIR = join(PACKAGE_DIR, "resources")
 
 Bounds = List[Tuple[float, float]]
 BoundsWithResolution = List[Tuple[float, float, int]]
+
+Viewer3DState = Union[Vispy3DViewerState, ViewerState3D]
 
 
 def data_count(layers: Iterable[Union[LayerArtist, LayerState]]) -> int:
@@ -61,14 +70,14 @@ def isomax_for_layer(viewer_state: ViewerState, layer_state: VolumeLayerState) -
 
 
 @overload
-def xyz_bounds(viewer_state: Vispy3DViewerState, with_resolution: Literal[False]) -> Bounds: ...
+def xyz_bounds(viewer_state: Viewer3DState, with_resolution: Literal[False]) -> Bounds: ...
 
 
 @overload
-def xyz_bounds(viewer_state: Vispy3DViewerState, with_resolution: Literal[True]) -> BoundsWithResolution: ...
+def xyz_bounds(viewer_state: Viewer3DState, with_resolution: Literal[True]) -> BoundsWithResolution: ...
 
 
-def xyz_bounds(viewer_state: Vispy3DViewerState, with_resolution: bool) -> Union[Bounds, BoundsWithResolution]:
+def xyz_bounds(viewer_state: Viewer3DState, with_resolution: bool) -> Union[Bounds, BoundsWithResolution]:
     bounds: Bounds = [(viewer_state.x_min, viewer_state.x_max),
                       (viewer_state.y_min, viewer_state.y_max),
                       (viewer_state.z_min, viewer_state.z_max)]
@@ -79,18 +88,18 @@ def xyz_bounds(viewer_state: Vispy3DViewerState, with_resolution: bool) -> Union
 
 
 @overload
-def bounds_3d_from_layers(viewer_state: Vispy3DViewerState,
+def bounds_3d_from_layers(viewer_state: Viewer3DState,
                           layer_states: Iterable[VispyLayerState],
                           with_resolution: Literal[False]) -> Bounds: ...
 
 
 @overload
-def bounds_3d_from_layers(viewer_state: Vispy3DViewerState,
+def bounds_3d_from_layers(viewer_state: Viewer3DState,
                           layer_states: Iterable[VispyLayerState],
                           with_resolution: Literal[True]) -> BoundsWithResolution: ...
 
 
-def bounds_3d_from_layers(viewer_state: Vispy3DViewerState,
+def bounds_3d_from_layers(viewer_state: Viewer3DState,
                           layer_states: Iterable[VispyLayerState],
                           with_resolution: bool) -> Union[Bounds, BoundsWithResolution]:
     mins = [inf, inf, inf]
@@ -139,7 +148,7 @@ def bring_into_clip(data, bounds: Union[Bounds, BoundsWithResolution], preserve_
     return scaled
 
 
-def mask_for_bounds(viewer_state: Vispy3DViewerState,
+def mask_for_bounds(viewer_state: Viewer3DState,
                     layer_state: LayerState,
                     bounds: Union[Bounds, BoundsWithResolution]):
     data = layer_state.layer
@@ -154,7 +163,7 @@ def mask_for_bounds(viewer_state: Vispy3DViewerState,
 
 # TODO: Worry about efficiency later
 # and just generally make this better
-def xyz_for_layer(viewer_state: Vispy3DViewerState,
+def xyz_for_layer(viewer_state: Viewer3DState,
                   layer_state: LayerState,
                   scaled: bool = False,
                   preserve_aspect: bool = True,

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 PACKAGE_DIR = dirname(abspath(__file__))
-AR_ICON = abspath(join(dirname(__file__), "ar"))
+AR_ICON = abspath(join(dirname(__file__), "ar.png"))
 RESOURCES_DIR = join(PACKAGE_DIR, "resources")
 
 Bounds = List[Tuple[float, float]]


### PR DESCRIPTION
This PR enables support for glue-jupyter's ipyvolume scatter viewer. This involved a bit of refactoring to make the scatter export methods flexible in order to support both viewer types. Currently the ipyvolume scatter export options class doesn't have any fields - the sphere geometry in ipyvolume has particular resolutions in both theta and phi, so we go with that. The same is true for the diamond geometry (it's actually just a very low-res sphere), and the box doesn't really have any options.

I couldn't get the circle2d geometry to work (it doesn't show anything for me in the viewer), but for that case we use spheres, just like vispy does.