### PR TITLE
Add support for ipyvolume volume viewer

### DIFF
--- a/glue_ar/__init__.py
+++ b/glue_ar/__init__.py
@@ -51,7 +51,9 @@ def setup_jupyter():
         pass
 
     from glue_jupyter.ipyvolume.scatter import IpyvolumeScatterView
+    from glue_jupyter.ipyvolume.volume import IpyvolumeVolumeView
     IpyvolumeScatterView.tools = [t for t in IpyvolumeScatterView.tools] + ["save:ar_jupyter"]
+    IpyvolumeVolumeView.tools = [t for t in IpyvolumeVolumeView.tools] + ["save:ar_jupyter"]
 
 
 def setup():

--- a/glue_ar/common/export_options.py
+++ b/glue_ar/common/export_options.py
@@ -65,6 +65,7 @@ class ARExportLayerOptionsRegistry(DictRegistry):
                  multiple: bool = False):
         def adder(export_method: Callable):
             self.add(layer_state_cls, name, layer_options_state, extensions, multiple, export_method)
+            return export_method
         return adder
 
 

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -40,7 +40,7 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
         (viewer_state.x_min, viewer_state.x_max),
         (viewer_state.z_min, viewer_state.z_max),
     )
-    resolution = viewer_state.resolution
+    resolution = getattr(viewer_state, 'resolution', None) or getattr(layer_state, 'max_resolution')
     x_range = viewer_state.x_max - viewer_state.x_min
     y_range = viewer_state.y_max - viewer_state.y_min
     z_range = viewer_state.z_max - viewer_state.z_min
@@ -141,7 +141,7 @@ def add_isosurface_layer_usd(
         (viewer_state.x_min, viewer_state.x_max),
         (viewer_state.z_min, viewer_state.z_max),
     )
-    resolution = viewer_state.resolution
+    resolution = getattr(viewer_state, 'resolution', None) or getattr(layer_state, 'max_resolution')
     x_range = viewer_state.x_max - viewer_state.x_min
     y_range = viewer_state.y_max - viewer_state.y_min
     z_range = viewer_state.z_max - viewer_state.z_min
@@ -164,3 +164,13 @@ def add_isosurface_layer_usd(
         points = [tuple((-1 + (index + 0.5) * side) for index, side in zip(pt, clip_sides)) for pt in points]
         points = [[p[1], p[0], p[2]] for p in points]
         builder.add_mesh(points, triangles, color_components, alpha)
+
+
+try:
+    from glue_jupyter.ipyvolume.volume import VolumeLayerState as IPVVolumeLayerState
+    ar_layer_export.add(IPVVolumeLayerState, "Isosurface", ARIsosurfaceExportOptions,
+                        ("gltf", "glb"), False, add_isosurface_layer_gltf)
+    ar_layer_export.add(IPVVolumeLayerState, "Isosurface", ARIsosurfaceExportOptions,
+                        ("usda", "usdc"), False, add_isosurface_layer_usd)
+except ImportError:
+    pass

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -9,7 +9,7 @@ from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.volume_export_options import ARVoxelExportOptions
 from glue_ar.usd_utils import material_for_color
-from glue_ar.utils import BoundsWithResolution, alpha_composite, frb_for_layer, hex_to_components, \
+from glue_ar.utils import BoundsWithResolution, alpha_composite, frb_for_layer, get_resolution, hex_to_components, \
                           isomin_for_layer, isomax_for_layer, layer_color, unique_id, xyz_bounds
 
 from glue_ar.gltf_utils import add_points_to_bytearray, add_triangles_to_bytearray, \
@@ -26,7 +26,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
                           options: Iterable[ARVoxelExportOptions],
                           bounds: Optional[BoundsWithResolution] = None):
 
-    resolution = viewer_state.resolution
+    resolution = get_resolution(viewer_state)
     bounds = bounds or xyz_bounds(viewer_state, with_resolution=True)
     x_range = viewer_state.x_max - viewer_state.x_min
     y_range = viewer_state.y_max - viewer_state.y_min
@@ -167,7 +167,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
                          options: Iterable[ARVoxelExportOptions],
                          bounds: Optional[BoundsWithResolution] = None):
 
-    resolution = viewer_state.resolution
+    resolution = get_resolution(viewer_state)
     bounds = bounds or xyz_bounds(viewer_state, with_resolution=True)
     x_range = viewer_state.x_max - viewer_state.x_min
     y_range = viewer_state.y_max - viewer_state.y_min
@@ -242,3 +242,13 @@ def add_voxel_layers_usd(builder: USDBuilder,
             builder.add_translated_reference(mesh, translation, material)
 
     return builder
+
+
+try:
+    from glue_jupyter.ipyvolume.volume import VolumeLayerState as IPVVolumeLayerState
+    ar_layer_export.add(IPVVolumeLayerState, "Voxel", ARVoxelExportOptions,
+                        ("gltf", "glb"), True, add_voxel_layers_gltf)
+    ar_layer_export.add(IPVVolumeLayerState, "Voxel", ARVoxelExportOptions,
+                        ("usda", "usdc"), True, add_voxel_layers_usd)
+except ImportError:
+    pass

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -3,11 +3,10 @@ from os.path import exists
 
 from glue.config import viewer_tool
 from glue.viewers.common.tool import Tool
-from glue_vispy_viewers.volume.qt.volume_viewer import VispyVolumeViewerMixin
 
 from glue_ar.common.export import export_viewer
 from glue_ar.jupyter.export_dialog import JupyterARExportDialog
-from glue_ar.utils import AR_ICON, xyz_bounds
+from glue_ar.utils import AR_ICON, is_volume_viewer, xyz_bounds
 
 import ipyvuetify as v  # noqa
 from ipywidgets import HBox, Layout # noqa
@@ -109,7 +108,7 @@ class JupyterARExportTool(Tool):
             self.viewer.output_widget.clear_output()
 
     def save_figure(self, filepath):
-        bounds = xyz_bounds(self.viewer.state, with_resolution=isinstance(self.viewer, VispyVolumeViewerMixin))
+        bounds = xyz_bounds(self.viewer.state, with_resolution=is_volume_viewer(self.viewer))
         layer_states = [layer.state for layer in self.viewer.layers if layer.enabled and layer.state.visible]
         state_dict = self.export_dialog.state_dictionary
         export_viewer(viewer_state=self.viewer.state,


### PR DESCRIPTION
This PR adds support for the ipyvolume volume viewer. Since this viewer's state class is derived from the VisPy volume viewer's state class, this is a pretty straightforward update.