### PR TITLE
Allow binning opacities in voxel export

### DIFF
--- a/glue_ar/common/volume_export_options.py
+++ b/glue_ar/common/volume_export_options.py
@@ -11,3 +11,4 @@ class ARIsosurfaceExportOptions(State):
 
 class ARVoxelExportOptions(State):
     opacity_cutoff = CallbackProperty(0.05)
+    opacity_bins = CallbackProperty(100)

--- a/glue_ar/common/volume_export_options.py
+++ b/glue_ar/common/volume_export_options.py
@@ -11,4 +11,4 @@ class ARIsosurfaceExportOptions(State):
 
 class ARVoxelExportOptions(State):
     opacity_cutoff = CallbackProperty(0.05)
-    opacity_bins = CallbackProperty(100)
+    opacity_resolution = CallbackProperty(0.01)

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -77,7 +77,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
     occupied_voxels = {}
 
     for layer_state, option in zip(layer_states, options):
-        opacity_cutoff = option.opacity_cutoff
+        opacity_cutoff = clamp(option.opacity_cutoff, 0, 1)
         opacity_resolution = clamp(option.opacity_resolution, 0, 1)
         data = frb_for_layer(viewer_state, layer_state, bounds)
 
@@ -193,7 +193,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
     occupied_voxels = {}
 
     for layer_state, option in zip(layer_states, options):
-        opacity_cutoff = option.opacity_cutoff
+        opacity_cutoff = clamp(option.opacity_cutoff, 0, 1)
         opacity_resolution = clamp(option.opacity_resolution, 0, 1)
         data = frb_for_layer(viewer_state, layer_state, bounds)
 

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -9,7 +9,7 @@ from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.volume_export_options import ARVoxelExportOptions
 from glue_ar.usd_utils import material_for_color
-from glue_ar.utils import BoundsWithResolution, alpha_composite, binned_opacity, clamped_opacity, \
+from glue_ar.utils import BoundsWithResolution, alpha_composite, binned_opacity, clamp, clamped_opacity, \
                           frb_for_layer, get_resolution, hex_to_components, isomin_for_layer, \
                           isomax_for_layer, layer_color, unique_id, xyz_bounds
 
@@ -78,7 +78,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
     for layer_state, option in zip(layer_states, options):
         opacity_cutoff = option.opacity_cutoff
-        opacity_resolution = option.opacity_resolution
+        opacity_resolution = clamp(option.opacity_resolution, 0, 1)
         data = frb_for_layer(viewer_state, layer_state, bounds)
 
         isomin = isomin_for_layer(viewer_state, layer_state)
@@ -194,7 +194,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
 
     for layer_state, option in zip(layer_states, options):
         opacity_cutoff = option.opacity_cutoff
-        opacity_resolution = option.opacity_resolution
+        opacity_resolution = clamp(option.opacity_resolution, 0, 1)
         data = frb_for_layer(viewer_state, layer_state, bounds)
 
         isomin = isomin_for_layer(viewer_state, layer_state)

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -278,3 +278,11 @@ def get_resolution(viewer_state: Viewer3DState) -> int:
         pass
 
     return 256
+
+
+def clamped_opacity(opacity: float) -> float:
+    return min(max(opacity, 0), 1)
+
+
+def binned_opacity(raw_opacity: float, resolution: float) -> float:
+    return clamped_opacity(round(raw_opacity / resolution) * resolution)

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -1,3 +1,4 @@
+from numbers import Number
 from os.path import abspath, dirname, join
 from uuid import uuid4
 from typing import Iterator, Literal, overload, Iterable, List, Optional, Tuple, Union
@@ -280,8 +281,13 @@ def get_resolution(viewer_state: Viewer3DState) -> int:
     return 256
 
 
+# TODO: What is the right typing here?
+def clamp(value: Number, minimum: Number, maximum: Number) -> Number:
+    return min(max(value, minimum), maximum)
+
+
 def clamped_opacity(opacity: float) -> float:
-    return min(max(opacity, 0), 1)
+    return clamp(opacity, 0, 1)
 
 
 def binned_opacity(raw_opacity: float, resolution: float) -> float:


### PR DESCRIPTION
This PR resolves #40 by allowing binning of opacities for the voxel export. Instead of specifying a bin count, this PR allows specifying the opacity resolution, and we then bin opacities by rounding to the nearest multiple of that value. This helps to (potentially) significantly reduce the number of materials without much visual impact (unless of course one makes the resolution very poor).