### PR TITLE
Prevent import errors if glue-jupyter is not installed

### DIFF
--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -1,5 +1,7 @@
 from functools import partial
 from numpy import clip, isfinite, isnan, ndarray, ones, sqrt
+
+# Backwards compatibility for Python < 3.10
 try:
     from types import NoneType
 except ImportError:

--- a/glue_ar/common/scatter.py
+++ b/glue_ar/common/scatter.py
@@ -1,24 +1,18 @@
 from functools import partial
 from numpy import clip, isfinite, isnan, ndarray, ones, sqrt
-
-# Backwards compatibility for Python < 3.10
-try:
-    from types import NoneType
-except ImportError:
-    NoneType = type(None)
 from typing import Callable, Dict, List, Optional, Tuple, Union
-
 
 from glue.utils import ensure_numerical
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
+
+from glue_ar.common.shapes import rectangular_prism_points, rectangular_prism_triangulation, \
+                                  sphere_points, sphere_triangles
+from glue_ar.utils import Bounds, NoneType, Viewer3DState, mask_for_bounds
+
 try:
     from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
 except ImportError:
     Scatter3DLayerState = NoneType
-
-from glue_ar.common.shapes import rectangular_prism_points, rectangular_prism_triangulation, \
-                                  sphere_points, sphere_triangles
-from glue_ar.utils import Bounds, Viewer3DState, mask_for_bounds
 
 ScatterLayerState3D = Union[ScatterLayerState, Scatter3DLayerState]
 

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -1,11 +1,20 @@
 from gltflib import AccessorType, BufferTarget, ComponentType, PrimitiveMode
-from glue_jupyter.common.state3d import ViewerState3D
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 from glue_vispy_viewers.volume.viewer_state import Vispy3DViewerState
 from numpy import array, isfinite, ndarray
 from numpy.linalg import norm
 
+# Backwards compatibility for Python < 3.10
+try:
+    from types import NoneType
+except ImportError:
+    NoneType = type(None)
 from typing import List, Literal, Optional, Tuple
+
+try:
+    from glue_jupyter.common.state3d import ViewerState3D
+except ImportError:
+    ViewerState3D = NoneType
 
 
 from glue_ar.common.export_options import ar_layer_export

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -4,17 +4,7 @@ from glue_vispy_viewers.volume.viewer_state import Vispy3DViewerState
 from numpy import array, isfinite, ndarray
 from numpy.linalg import norm
 
-# Backwards compatibility for Python < 3.10
-try:
-    from types import NoneType
-except ImportError:
-    NoneType = type(None)
 from typing import List, Literal, Optional, Tuple
-
-try:
-    from glue_jupyter.common.state3d import ViewerState3D
-except ImportError:
-    ViewerState3D = NoneType
 
 
 from glue_ar.common.export_options import ar_layer_export
@@ -28,7 +18,12 @@ from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.scatter import Scatter3DLayerState, ScatterLayerState3D, \
                                    PointsGetter, box_points_getter, IPYVOLUME_POINTS_GETTERS, \
                                    IPYVOLUME_TRIANGLE_GETTERS, VECTOR_OFFSETS, radius_for_scatter_layer, \
-                                   scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
+                                   scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter, NoneType
+
+try:
+    from glue_jupyter.common.state3d import ViewerState3D
+except ImportError:
+    ViewerState3D = NoneType
 
 
 def add_vectors_gltf(builder: GLTFBuilder,

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -1,16 +1,5 @@
-# Backwards compatibility for Python < 3.10
-try:
-    from types import NoneType
-except ImportError:
-    NoneType = type(None)
 from typing import List, Optional, Tuple
 
-try:
-    from glue_jupyter.common.state3d import ViewerState3D
-    from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
-except ImportError:
-    ViewerState3D = NoneType
-    Scatter3DLayerState = NoneType
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 from glue_vispy_viewers.scatter.viewer_state import Vispy3DViewerState
 from numpy import array, ndarray
@@ -25,8 +14,15 @@ from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.shapes import cone_triangles, cone_points, cylinder_points, cylinder_triangles, \
                                   normalize, rectangular_prism_triangulation, sphere_triangles
 from glue_ar.utils import Viewer3DState, export_label_for_layer, iterable_has_nan, hex_to_components, \
-                          layer_color, xyz_for_layer, Bounds
+                          layer_color, xyz_for_layer, Bounds, NoneType
 from glue_ar.usd_utils import material_for_color
+
+try:
+    from glue_jupyter.common.state3d import ViewerState3D
+    from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
+except ImportError:
+    ViewerState3D = NoneType
+    Scatter3DLayerState = NoneType
 
 
 def add_vectors_usd(builder: USDBuilder,

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -1,7 +1,16 @@
+# Backwards compatibility for Python < 3.10
+try:
+    from types import NoneType
+except ImportError:
+    NoneType = type(None)
 from typing import List, Optional, Tuple
 
-from glue_jupyter.common.state3d import ViewerState3D
-from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
+try:
+    from glue_jupyter.common.state3d import ViewerState3D
+    from glue_jupyter.ipyvolume.scatter import Scatter3DLayerState
+except ImportError:
+    ViewerState3D = NoneType
+    Scatter3DLayerState = NoneType
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 from glue_vispy_viewers.scatter.viewer_state import Vispy3DViewerState
 from numpy import array, ndarray

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     ViewerState3D = Vispy3DViewerState
 
+# Backwards compatibility for Python < 3.10
+try:
+    from types import NoneType  # noqa
+except ImportError:
+    NoneType = type(None)
 
 PACKAGE_DIR = dirname(abspath(__file__))
 AR_ICON = abspath(join(dirname(__file__), "ar.png"))


### PR DESCRIPTION
This PR fixes up a few places where import errors can pop up if glue-jupyter isn't installed.