### PR TITLE
Update start_worker signature

### DIFF
--- a/glue_ar/qt/export_tool.py
+++ b/glue_ar/qt/export_tool.py
@@ -63,11 +63,11 @@ class QtARExportTool(Tool):
                            filepath=export_path,
                            compression=dialog.state.compression)
 
-    def _start_worker(self, *args, **kwargs):
+    def _start_worker(self, exporter, **kwargs):
         _, ext = splitext(kwargs["filepath"])
         ext = ext[1:]
         filetype = _FILETYPE_NAMES.get(ext, None)
-        worker = Worker(*args, **kwargs)
+        worker = Worker(exporter, **kwargs)
         exporting_dialog = ExportingDialog(parent=self.viewer, filetype=filetype)
         worker.result.connect(exporting_dialog.close)
         worker.error.connect(exporting_dialog.close)


### PR DESCRIPTION
We should only ever be passing one non-keyword argument to `start_worker`, and the `Worker` that it creates, so this PR updates the function signature to reflect that.