### PR TITLE
Sanitize USD paths to prevent having dashes

### DIFF
--- a/glue_ar/common/usd_builder.py
+++ b/glue_ar/common/usd_builder.py
@@ -15,8 +15,11 @@ class USDBuilder:
         self._create_stage(filepath)
         self._material_map: Dict[MaterialInfo, UsdShade.Shader] = {}
 
+    def _sanitize(self, identifier: str) -> str:
+        return identifier.replace("-", "_")
+
     def _create_stage(self, filepath: str):
-        self.stage = Usd.Stage.CreateNew(filepath)
+        self.stage = Usd.Stage.CreateNew(self._sanitize(filepath))
 
         # TODO: Do we want to make changing this an option?
         UsdGeom.SetStageUpAxis(self.stage, UsdGeom.Tokens.y)
@@ -63,6 +66,7 @@ class USDBuilder:
         for other meshes that we create.
         """
         identifier = identifier or unique_id()
+        identifier = self._sanitize(identifier)
         count = self._mesh_counts[identifier]
         xform_key = f"{self.default_prim_key}/xform_{identifier}_{count}"
         UsdGeom.Xform.Define(self.stage, xform_key)
@@ -87,6 +91,7 @@ class USDBuilder:
                                  identifier: Optional[str] = None) -> UsdGeom.Mesh:
         prim = mesh.GetPrim()
         identifier = identifier or unique_id()
+        identifier = self._sanitize(identifier)
         count = self._mesh_counts[identifier]
         xform_key = f"{self.default_prim_key}/xform_{identifier}_{count}"
         UsdGeom.Xform.Define(self.stage, xform_key)


### PR DESCRIPTION
It seems that USD paths can't contain hyphens. I can't find this anywhere in the docs (and I'm not alone in that: see [here](https://www.sidefx.com/forum/topic/86000/) and [here](https://stackoverflow.com/questions/75535380/is-there-a-rule-about-hyphens-in-primvar-names-in-universal-scene-description)), which made this an annoying issue to solve, but it definitely seems to be a thing. So this PR sanitizes our USD paths to avoid having hyphens.