### PR TITLE
Allow exporting to USDZ

### DIFF
--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -28,7 +28,8 @@ _BUILDERS = {
     "gltf": GLTFBuilder,
     "glb": GLTFBuilder,
     "usda": USDBuilder,
-    "usdc": USDBuilder
+    "usdc": USDBuilder,
+    "usdz": USDBuilder,
 }
 
 

--- a/glue_ar/common/export_state.py
+++ b/glue_ar/common/export_state.py
@@ -23,7 +23,7 @@ class ARExportDialogState(State):
         super(ARExportDialogState, self).__init__()
 
         self.filetype_helper = ComboHelper(self, 'filetype')
-        self.filetype_helper.choices = ['glB', 'glTF', 'USDC', 'USDA']
+        self.filetype_helper.choices = ['glB', 'glTF', 'USDZ', 'USDC', 'USDA']
 
         self.compression_helper = ComboHelper(self, 'compression')
         self.compression_helper.choices = ['None', 'Draco', 'Meshoptimizer']

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -114,7 +114,7 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
         builder.add_file_resource(level_bin, data=barr)
 
 
-@ar_layer_export(VolumeLayerState, "Isosurface", ARIsosurfaceExportOptions, ("usdc", "usda"))
+@ar_layer_export(VolumeLayerState, "Isosurface", ARIsosurfaceExportOptions, ("usdz", "usdc", "usda"))
 def add_isosurface_layer_usd(
     builder: USDBuilder,
     viewer_state: Vispy3DVolumeViewerState,
@@ -171,6 +171,6 @@ try:
     ar_layer_export.add(IPVVolumeLayerState, "Isosurface", ARIsosurfaceExportOptions,
                         ("gltf", "glb"), False, add_isosurface_layer_gltf)
     ar_layer_export.add(IPVVolumeLayerState, "Isosurface", ARIsosurfaceExportOptions,
-                        ("usda", "usdc"), False, add_isosurface_layer_usd)
+                        ("usda", "usdc", "usdz"), False, add_isosurface_layer_usd)
 except ImportError:
     pass

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -188,7 +188,7 @@ def add_scatter_layer_usd(
         )
 
 
-@ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("usdc", "usda"))
+@ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("usdz", "usdc", "usda"))
 def add_vispy_scatter_layer_usd(builder: USDBuilder,
                                 viewer_state: Vispy3DViewerState,
                                 layer_state: ScatterLayerState,
@@ -211,7 +211,7 @@ def add_vispy_scatter_layer_usd(builder: USDBuilder,
                           clip_to_bounds=clip_to_bounds)
 
 
-@ar_layer_export(Scatter3DLayerState, "Scatter", ARIpyvolumeScatterExportOptions, ("usdc", "usda"))
+@ar_layer_export(Scatter3DLayerState, "Scatter", ARIpyvolumeScatterExportOptions, ("usdz", "usdc", "usda"))
 def add_ipyvolume_scatter_layer_usd(builder: USDBuilder,
                                     viewer_state: ViewerState3D,
                                     layer_state: Scatter3DLayerState,

--- a/glue_ar/common/tests/test_base_dialog.py
+++ b/glue_ar/common/tests/test_base_dialog.py
@@ -49,7 +49,7 @@ class BaseExportDialogTest:
         assert state.layer == "Volume Data"
         assert state.method in {"Isosurface", "Voxel"}
 
-        assert state.filetype_helper.choices == ['glB', 'glTF', 'USDC', 'USDA']
+        assert state.filetype_helper.choices == ['glB', 'glTF', 'USDZ', 'USDC', 'USDA']
         assert state.compression_helper.choices == ['None', 'Draco', 'Meshoptimizer']
         assert state.layer_helper.choices == ["Volume Data", "Scatter Data"]
         assert set(state.method_helper.choices) == {"Isosurface", "Voxel"}

--- a/glue_ar/common/usd_builder.py
+++ b/glue_ar/common/usd_builder.py
@@ -129,5 +129,5 @@ class USDBuilder:
         else:
             self.stage.GetRootLayer().Export(filepath)
 
-    def build_and_export(self, filepath):
+    def build_and_export(self, filepath: str):
         self.export(filepath)

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -162,7 +162,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
     builder.add_file_resource(triangles_bin, data=triangles_barr)
 
 
-@ar_layer_export(VolumeLayerState, "Voxel", ARVoxelExportOptions, ("usda", "usdc"), multiple=True)
+@ar_layer_export(VolumeLayerState, "Voxel", ARVoxelExportOptions, ("usda", "usdc", "usdz"), multiple=True)
 def add_voxel_layers_usd(builder: USDBuilder,
                          viewer_state: Vispy3DVolumeViewerState,
                          layer_states: Iterable[VolumeLayerState],
@@ -252,6 +252,6 @@ try:
     ar_layer_export.add(IPVVolumeLayerState, "Voxel", ARVoxelExportOptions,
                         ("gltf", "glb"), True, add_voxel_layers_gltf)
     ar_layer_export.add(IPVVolumeLayerState, "Voxel", ARVoxelExportOptions,
-                        ("usda", "usdc"), True, add_voxel_layers_usd)
+                        ("usda", "usdc", "usdz"), True, add_voxel_layers_usd)
 except ImportError:
     pass

--- a/glue_ar/jupyter/tests/test_dialog.py
+++ b/glue_ar/jupyter/tests/test_dialog.py
@@ -49,8 +49,9 @@ class TestJupyterExportDialog(BaseExportDialogTest):
         assert self.dialog.filetype_items == [
             {"text": "glB", "value": 0},
             {"text": "glTF", "value": 1},
-            {"text": "USDC", "value": 2},
-            {"text": "USDA", "value": 3}
+            {"text": "USDZ", "value": 2},
+            {"text": "USDC", "value": 3},
+            {"text": "USDA", "value": 4},
         ]
         assert self.dialog.filetype_selected == 0
         assert set([item["text"] for item in self.dialog.method_items]) == {"Isosurface", "Voxel"}

--- a/glue_ar/qt/export_tool.py
+++ b/glue_ar/qt/export_tool.py
@@ -18,6 +18,7 @@ __all__ = ["ARToolMenu", "QtARExportTool"]
 _FILETYPE_NAMES = {
     "gltf": "glTF",
     "glb": "glB",
+    "usdz": "USDZ",
     "usdc": "USDC",
     "usda": "USDA",
 }

--- a/glue_ar/qt/tests/test_tool_scatter.py
+++ b/glue_ar/qt/tests/test_tool_scatter.py
@@ -55,7 +55,7 @@ class TestScatterExportTool:
         assert len([subtool for subtool in tool.subtools if isinstance(subtool, QtARExportTool)]) == 1
 
     @pytest.mark.parametrize("extension,compression",
-                             product(("glB", "glTF", "USDA", "USDC"), ("None", "Draco", "Meshoptimizer")))
+                             product(("glB", "glTF", "USDA", "USDC", "USDZ"), ("None", "Draco", "Meshoptimizer")))
     def test_tool_export_call(self, extension, compression):
         auto_accept = dialog_auto_accept_with_options(filetype=extension, compression=compression)
         with patch("qtpy.compat.getsavefilename") as fd, \

--- a/glue_ar/qt/tests/test_tool_volume.py
+++ b/glue_ar/qt/tests/test_tool_volume.py
@@ -60,7 +60,7 @@ class TestVolumeExportTool:
         assert len([subtool for subtool in tool.subtools if isinstance(subtool, QtARExportTool)]) == 1
 
     @pytest.mark.parametrize("extension,compression",
-                             product(("glB", "glTF", "USDA", "USDC"), ("None", "Draco", "Meshoptimizer")))
+                             product(("glB", "glTF", "USDA", "USDC", "USDZ"), ("None", "Draco", "Meshoptimizer")))
     def test_tool_export_call(self, extension, compression):
         auto_accept = dialog_auto_accept_with_options(filetype=extension, compression=compression)
         with patch("qtpy.compat.getsavefilename") as fd, \


### PR DESCRIPTION
This PR updates our USD builder to allow exporting to USDZ. Since this is the primary USD filetype that we'll want for Apple devices, the ability to do this is a nice gain for us.