### PR TITLE
Replace parentheses in USD path names

### DIFF
--- a/glue_ar/common/usd_builder.py
+++ b/glue_ar/common/usd_builder.py
@@ -22,7 +22,10 @@ class USDBuilder:
         self._material_map: Dict[MaterialInfo, UsdShade.Shader] = {}
 
     def _sanitize(self, identifier: str) -> str:
-        return identifier.replace("-", "_")
+        # TODO: Do this in a single pass
+        for char in ("-", "(", ")"):
+            identifier = identifier.replace(char, "_")
+        return identifier
 
     def _create_stage(self, filepath: str):
         self.stage = Usd.Stage.CreateNew(self._sanitize(filepath))


### PR DESCRIPTION
Follow-up to #57. It seems that parentheses aren't allowed either, so we remove those as well.