### PR TITLE
Use README for package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,10 @@ file formats include [glTF/glB](https://www.khronos.org/gltf/) and [USD](https:/
 
 ## Installation
 
-This package is not (yet) listed on PyPI, so to install you'll need to clone this repository and install from source.
+This package is pip-installable:
 
 ```
-git clone https://github.com/Carifio24/glue-ar
-cd glue-ar
-pip install .  # Use `pip install -e .` to install in editable mode
+pip install glue-ar
 ```
 
 Installation requires Node.js to be installed on your system, as we currently use JavaScript packages for performing

--- a/setup.py
+++ b/setup.py
@@ -727,10 +727,15 @@ cmdclass = create_cmdclass(
 )
 cmdclass["js-content"] = js_content_command
 
+with open("README.md", 'r') as f:
+    description = f.read()
+
 # TODO: Add the rest of the package data
 setup_args = dict(
     name=name,
     cmdclass=cmdclass,
+    long_description=description,
+    long_description_content_type="text/markdown",
     python_requires=">=3.9",
     zip_safe=False,
     packages=find_packages(name, exclude=["js"]),


### PR DESCRIPTION
This is a small PR that updates our setup script to use the README as the package description. Additionally, this also updates the README to mention that the package is now pip-installable.
