### PR TITLE
Account for scatter layers when determining ipyvolume volume resolution

### DIFF
--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -279,7 +279,8 @@ def get_resolution(viewer_state: Viewer3DState) -> int:
     try:
         from glue_jupyter.common.state3d import VolumeViewerState
         if isinstance(viewer_state, VolumeViewerState):
-            return max((getattr(state, 'max_resolution', 256) for state in viewer_state.layers), default=256)
+            resolutions = tuple(getattr(state, 'max_resolution', None) for state in viewer_state.layers)
+            return max((res for res in resolutions if res is not None), default=256)
     except ImportError:
         pass
 


### PR DESCRIPTION
Currently if an ipyvolume volume viewer contains scatter layers, the viewer resolution will always be returned as 256, regardless of what the volume layers are doing. This is due to the default value in the `getattr` call. This PR updates the resolution calculation to ignore layers that don't have a `max_resolution` attribute.
