### PR TITLE
STL export

### DIFF
--- a/glue_ar/common/__init__.py
+++ b/glue_ar/common/__init__.py
@@ -1,5 +1,6 @@
 from .marching_cubes import add_isosurface_layer_gltf, add_isosurface_layer_usd  # noqa: F401
 from .scatter_gltf import add_scatter_layer_gltf  # noqa: F401
+from .scatter_stl import add_scatter_layer_stl  # noqa: F401
 from .scatter_usd import add_scatter_layer_usd  # noqa: F401
 from .voxels import add_voxel_layers_gltf, add_voxel_layers_usd  # noqa: F401
 from .scatter_export_options import ARVispyScatterExportOptions  # noqa: F401

--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -12,6 +12,7 @@ from glue_vispy_viewers.volume.layer_state import VolumeLayerState
 
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.gltf_builder import GLTFBuilder
+from glue_ar.common.stl_builder import STLBuilder
 from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.utils import PACKAGE_DIR, RESOURCES_DIR, Bounds, BoundsWithResolution, export_label_for_layer
 
@@ -30,6 +31,7 @@ _BUILDERS = {
     "usda": USDBuilder,
     "usdc": USDBuilder,
     "usdz": USDBuilder,
+    "stl": STLBuilder,
 }
 
 

--- a/glue_ar/common/export_state.py
+++ b/glue_ar/common/export_state.py
@@ -23,7 +23,7 @@ class ARExportDialogState(State):
         super(ARExportDialogState, self).__init__()
 
         self.filetype_helper = ComboHelper(self, 'filetype')
-        self.filetype_helper.choices = ['glB', 'glTF', 'USDZ', 'USDC', 'USDA']
+        self.filetype_helper.choices = ['glB', 'glTF', 'USDZ', 'USDC', 'USDA', 'STL']
 
         self.compression_helper = ComboHelper(self, 'compression')
         self.compression_helper.choices = ['None', 'Draco', 'Meshoptimizer']

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gltflib import Accessor, AccessorType, AlphaMode, Asset, Attributes, Buffer, \
                     BufferTarget, BufferView, ComponentType, GLTFModel, \
                     Material, Mesh, Node, PBRMetallicRoughness, Primitive, PrimitiveMode, Scene

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gltflib import Accessor, AccessorType, AlphaMode, Asset, Attributes, Buffer, \
                     BufferTarget, BufferView, ComponentType, GLTFModel, \
                     Material, Mesh, Node, PBRMetallicRoughness, Primitive, PrimitiveMode, Scene

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -152,5 +152,5 @@ class GLTFBuilder:
         model = self.build_model()
         return GLTF(model=model, resources=self.file_resources)
 
-    def build_and_export(self, filepath):
+    def build_and_export(self, filepath: str):
         self.build().export(filepath)

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -185,9 +185,6 @@ def add_isosurface_layer_stl(
 
     isosurface_count = int(options.isosurface_count)
     levels = linspace(isomin, isomax, isosurface_count)
-    opacity = layer_state.alpha
-    color = layer_color(layer_state)
-    # color_components = tuple(hex_to_components(color))
 
     world_bounds = (
         (viewer_state.y_min, viewer_state.y_max),
@@ -229,6 +226,3 @@ try:
                         ("stl",), False, add_isosurface_layer_stl)
 except ImportError:
     pass
-
-
-

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -1,6 +1,6 @@
 from gltflib import AccessorType, BufferTarget, ComponentType, PrimitiveMode
+from glue_vispy_viewers.common.viewer_state import Vispy3DViewerState
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
-from glue_vispy_viewers.volume.viewer_state import Vispy3DViewerState
 from numpy import array, isfinite, ndarray
 from numpy.linalg import norm
 

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -361,11 +361,13 @@ def add_vispy_scatter_layer_gltf(builder: GLTFBuilder,
                                  bounds: Bounds,
                                  clip_to_bounds: bool = True):
 
-    triangles = sphere_triangles(theta_resolution=options.theta_resolution,
-                                 phi_resolution=options.phi_resolution)
+    theta_resolution = int(options.theta_resolution)
+    phi_resolution = int(options.phi_resolution)
+    triangles = sphere_triangles(theta_resolution=theta_resolution,
+                                 phi_resolution=phi_resolution)
 
-    points_getter = sphere_points_getter(theta_resolution=options.theta_resolution,
-                                         phi_resolution=options.phi_resolution)
+    points_getter = sphere_points_getter(theta_resolution=theta_resolution,
+                                         phi_resolution=phi_resolution)
 
     add_scatter_layer_gltf(builder=builder,
                            viewer_state=viewer_state,

--- a/glue_ar/common/scatter_stl.py
+++ b/glue_ar/common/scatter_stl.py
@@ -4,7 +4,8 @@ from glue_vispy_viewers.common.viewer_state import Vispy3DViewerState
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 
 from glue_ar.common.export_options import ar_layer_export
-from glue_ar.common.scatter import PointsGetter, ScatterLayerState3D, radius_for_scatter_layer, scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
+from glue_ar.common.scatter import PointsGetter, ScatterLayerState3D, radius_for_scatter_layer, \
+                                   scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
 from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
 from glue_ar.common.shapes import sphere_triangles
 from glue_ar.common.stl_builder import STLBuilder
@@ -24,10 +25,7 @@ def add_scatter_layer_stl(builder: STLBuilder,
 
     bounds = xyz_bounds(viewer_state, with_resolution=False)
 
-    vispy_layer_state = isinstance(layer_state, ScatterLayerState)
     fixed_size = layer_state.size_mode == "Fixed"
-    color_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
-    fixed_color = getattr(layer_state, color_mode_attr, "Fixed") == "Fixed"
     radius = radius_for_scatter_layer(layer_state)
     mask = scatter_layer_mask(viewer_state, layer_state, bounds, clip_to_bounds)
 
@@ -60,9 +58,9 @@ def add_vispy_scatter_layer_stl(builder: STLBuilder,
                                          phi_resolution=options.phi_resolution)
 
     add_scatter_layer_stl(builder=builder,
-                         viewer_state=viewer_state,
-                         layer_state=layer_state,
-                         points_getter=points_getter,
-                         triangles=triangles,
-                         bounds=bounds,
-                         clip_to_bounds=clip_to_bounds)
+                          viewer_state=viewer_state,
+                          layer_state=layer_state,
+                          points_getter=points_getter,
+                          triangles=triangles,
+                          bounds=bounds,
+                          clip_to_bounds=clip_to_bounds)

--- a/glue_ar/common/scatter_stl.py
+++ b/glue_ar/common/scatter_stl.py
@@ -4,7 +4,7 @@ from glue_vispy_viewers.common.viewer_state import Vispy3DViewerState
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 
 from glue_ar.common.export_options import ar_layer_export
-from glue_ar.common.scatter import IPYVOLUME_POINTS_GETTERS, IPYVOLUME_TRIANGLE_GETTERS, VECTOR_OFFSETS, PointsGetter, \
+from glue_ar.common.scatter import IPYVOLUME_POINTS_GETTERS, IPYVOLUME_TRIANGLE_GETTERS, PointsGetter, \
                                    ScatterLayerState3D, box_points_getter, radius_for_scatter_layer, \
                                    scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
 from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions

--- a/glue_ar/common/scatter_stl.py
+++ b/glue_ar/common/scatter_stl.py
@@ -1,0 +1,35 @@
+from typing import List, Tuple
+
+from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
+
+from glue_ar.common.scatter import PointsGetter, ScatterLayerState3D, radius_for_scatter_layer, scatter_layer_mask
+from glue_ar.common.stl_builder import STLBuilder
+from glue_ar.utils import Bounds, Viewer3DState, xyz_bounds, xyz_for_layer
+
+
+def add_scatter_layer_stl(builder: STLBuilder,
+                          viewer_state: Viewer3DState,
+                          layer_state: ScatterLayerState3D,
+                          points_getter: PointsGetter,
+                          triangles: List[Tuple[int, int, int]],
+                          bounds: Bounds,
+                          clip_to_bounds: bool = True):
+
+    if layer_state is None:
+        return
+
+    bounds = xyz_bounds(viewer_state, with_resolution=False)
+
+    vispy_layer_state = isinstance(layer_state, ScatterLayerState)
+    fixed_size = layer_state.size_mode == "Fixed"
+    color_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
+    fixed_color = getattr(layer_state, color_mode_attr, "Fixed") == "Fixed"
+    radius = radius_for_scatter_layer(layer_state)
+    mask = scatter_layer_mask(viewer_state, layer_state, bounds, clip_to_bounds)
+
+    data = xyz_for_layer(viewer_state, layer_state,
+                         preserve_aspect=viewer_state.native_aspect,
+                         mask=mask,
+                         scaled=True)
+    data = data[:, [1, 2, 0]]
+

--- a/glue_ar/common/scatter_stl.py
+++ b/glue_ar/common/scatter_stl.py
@@ -58,11 +58,14 @@ def add_vispy_scatter_layer_stl(builder: STLBuilder,
                                 options: ARVispyScatterExportOptions,
                                 bounds: Bounds,
                                 clip_to_bounds: bool = True):
-    triangles = sphere_triangles(theta_resolution=options.theta_resolution,
-                                 phi_resolution=options.phi_resolution)
 
-    points_getter = sphere_points_getter(theta_resolution=options.theta_resolution,
-                                         phi_resolution=options.phi_resolution)
+    theta_resolution = int(options.theta_resolution)
+    phi_resolution = int(options.phi_resolution)
+    triangles = sphere_triangles(theta_resolution=theta_resolution,
+                                 phi_resolution=phi_resolution)
+
+    points_getter = sphere_points_getter(theta_resolution=theta_resolution,
+                                         phi_resolution=phi_resolution)
 
     add_scatter_layer_stl(builder=builder,
                           viewer_state=viewer_state,

--- a/glue_ar/common/scatter_stl.py
+++ b/glue_ar/common/scatter_stl.py
@@ -1,8 +1,12 @@
 from typing import List, Tuple
 
+from glue_vispy_viewers.common.viewer_state import Vispy3DViewerState
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 
-from glue_ar.common.scatter import PointsGetter, ScatterLayerState3D, radius_for_scatter_layer, scatter_layer_mask
+from glue_ar.common.export_options import ar_layer_export
+from glue_ar.common.scatter import PointsGetter, ScatterLayerState3D, radius_for_scatter_layer, scatter_layer_mask, sizes_for_scatter_layer, sphere_points_getter
+from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
+from glue_ar.common.shapes import sphere_triangles
 from glue_ar.common.stl_builder import STLBuilder
 from glue_ar.utils import Bounds, Viewer3DState, xyz_bounds, xyz_for_layer
 
@@ -33,3 +37,32 @@ def add_scatter_layer_stl(builder: STLBuilder,
                          scaled=True)
     data = data[:, [1, 2, 0]]
 
+    sizes = sizes_for_scatter_layer(layer_state, bounds, mask)
+    for i, point in enumerate(data):
+
+        size = radius if fixed_size else sizes[i]
+        pts = points_getter(point, size)
+        builder.add_mesh(pts, triangles)
+
+
+@ar_layer_export(ScatterLayerState, "Scatter", ARVispyScatterExportOptions, ("stl",))
+def add_vispy_scatter_layer_stl(builder: STLBuilder,
+                                viewer_state: Vispy3DViewerState,
+                                layer_state: ScatterLayerState,
+                                options: ARVispyScatterExportOptions,
+                                bounds: Bounds,
+                                clip_to_bounds: bool = True):
+
+    triangles = sphere_triangles(theta_resolution=options.theta_resolution,
+                                 phi_resolution=options.phi_resolution)
+
+    points_getter = sphere_points_getter(theta_resolution=options.theta_resolution,
+                                         phi_resolution=options.phi_resolution)
+
+    add_scatter_layer_stl(builder=builder,
+                         viewer_state=viewer_state,
+                         layer_state=layer_state,
+                         points_getter=points_getter,
+                         triangles=triangles,
+                         bounds=bounds,
+                         clip_to_bounds=clip_to_bounds)

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -196,11 +196,13 @@ def add_vispy_scatter_layer_usd(builder: USDBuilder,
                                 bounds: Bounds,
                                 clip_to_bounds: bool = True):
 
-    triangles = sphere_triangles(theta_resolution=options.theta_resolution,
-                                 phi_resolution=options.phi_resolution)
+    theta_resolution = int(options.theta_resolution)
+    phi_resolution = int(options.phi_resolution)
+    triangles = sphere_triangles(theta_resolution=theta_resolution,
+                                 phi_resolution=phi_resolution)
 
-    points_getter = sphere_points_getter(theta_resolution=options.theta_resolution,
-                                         phi_resolution=options.phi_resolution)
+    points_getter = sphere_points_getter(theta_resolution=theta_resolution,
+                                         phi_resolution=phi_resolution)
 
     add_scatter_layer_usd(builder=builder,
                           viewer_state=viewer_state,

--- a/glue_ar/common/stl_builder.py
+++ b/glue_ar/common/stl_builder.py
@@ -1,4 +1,6 @@
-from numpy import array, zeros
+from __future__ import annotations
+
+from numpy import array, concatenate, zeros
 from stl import Mesh
 from typing import Iterable, List
 
@@ -24,7 +26,7 @@ class STLBuilder:
         return self
 
     def build(self) -> Mesh:
-        return Mesh([mesh.data for mesh in self.meshes])
+        return Mesh(concatenate([mesh.data for mesh in self.meshes]))
 
     def build_and_export(self, filepath: str):
         mesh = self.build()

--- a/glue_ar/common/stl_builder.py
+++ b/glue_ar/common/stl_builder.py
@@ -1,0 +1,31 @@
+from numpy import array, zeros
+from stl import Mesh
+from typing import Iterable, List
+
+
+class STLBuilder:
+
+    def __init__(self):
+        self.meshes: List[Mesh] = []
+
+    def add_mesh(self,
+                 vertices: List[Iterable[float]],
+                 triangles: List[Iterable[int]]) -> STLBuilder:
+
+        # Adapted from example at https://pypi.org/project/numpy-stl/
+        verts_array = array(vertices)
+        tris_array = array(triangles)
+        mesh = Mesh(zeros(tris_array.shape[0], dtype=Mesh.dtype))
+        for i, f in enumerate(tris_array):
+            for j in range(3):
+                mesh.vectors[i][j] = verts_array[f[j],:]
+
+        self.meshes.append(mesh)
+        return self
+
+    def build(self) -> Mesh:
+        return Mesh([mesh.data for mesh in self.meshes])
+
+    def build_and_export(self, filepath: str):
+        mesh = self.build()
+        mesh.save(filepath)

--- a/glue_ar/common/stl_builder.py
+++ b/glue_ar/common/stl_builder.py
@@ -20,7 +20,7 @@ class STLBuilder:
         mesh = Mesh(zeros(tris_array.shape[0], dtype=Mesh.dtype))
         for i, f in enumerate(tris_array):
             for j in range(3):
-                mesh.vectors[i][j] = verts_array[f[j],:]
+                mesh.vectors[i][j] = verts_array[f[j], :]
 
         self.meshes.append(mesh)
         return self

--- a/glue_ar/common/tests/test_base_dialog.py
+++ b/glue_ar/common/tests/test_base_dialog.py
@@ -49,7 +49,7 @@ class BaseExportDialogTest:
         assert state.layer == "Volume Data"
         assert state.method in {"Isosurface", "Voxel"}
 
-        assert state.filetype_helper.choices == ['glB', 'glTF', 'USDZ', 'USDC', 'USDA']
+        assert state.filetype_helper.choices == ['glB', 'glTF', 'USDZ', 'USDC', 'USDA', 'STL']
         assert state.compression_helper.choices == ['None', 'Draco', 'Meshoptimizer']
         assert state.layer_helper.choices == ["Volume Data", "Scatter Data"]
         assert set(state.method_helper.choices) == {"Isosurface", "Voxel"}

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -97,7 +97,7 @@ class TestScatterGLTF(BaseScatterTest):
                              scaled=True)
         data = data[:, [1, 2, 0]]
 
-        # Unpack the center of each sphere mesh matches the
+        # Check that the center of each sphere mesh matches the
         # corresponding data point
         tolerance = 1e-7
         for index, mesh in enumerate(model.meshes):

--- a/glue_ar/common/tests/test_scatter_stl.py
+++ b/glue_ar/common/tests/test_scatter_stl.py
@@ -1,0 +1,41 @@
+from sys import platform
+from tempfile import NamedTemporaryFile
+
+import pytest
+from stl import Mesh
+
+from glue_ar.common.export import export_viewer
+from glue_ar.common.tests.helpers import APP_VIEWER_OPTIONS
+from glue_ar.common.tests.test_scatter import BaseScatterTest
+from glue_ar.utils import layers_to_export, mask_for_bounds, xyz_bounds, xyz_for_layer
+
+
+class TestScatterSTL(BaseScatterTest):
+
+    @pytest.mark.parametrize("app_type,viewer_type", APP_VIEWER_OPTIONS)
+    def test_basic_export(self, app_type: str, viewer_type: str):
+        if app_type == "jupyter" and viewer_type == "vispy" and platform == "win32":
+            return
+        self.basic_setup(app_type, viewer_type)
+        bounds = xyz_bounds(self.viewer.state, with_resolution=False)
+        self.tmpfile = NamedTemporaryFile(suffix=".stl", delete=False)
+        self.tmpfile.close()
+        layer_states = [layer.state for layer in layers_to_export(self.viewer)]
+        export_viewer(self.viewer.state,
+                      layer_states=layer_states,
+                      bounds=bounds,
+                      state_dictionary=self.state_dictionary,
+                      filepath=self.tmpfile.name,
+                      compression=None)
+
+        stl = Mesh.from_file(self.tmpfile.name)
+
+        mask = mask_for_bounds(self.viewer.state, layer.state, bounds)
+        data = xyz_for_layer(self.viewer.state, layer.state,
+                             preserve_aspect=self.viewer.state.native_aspect,
+                             mask=mask,
+                             scaled=True)
+
+        print(self.data1['x'][0], self.data1['y'][0], self.data1['z'][0])
+        print(stl.points[:82])
+        assert False

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -6,6 +6,7 @@ from glue_vispy_viewers.volume.layer_state import VolumeLayerState
 
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.gltf_builder import GLTFBuilder
+from glue_ar.common.stl_builder import STLBuilder
 from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.volume_export_options import ARVoxelExportOptions
 from glue_ar.usd_utils import material_for_color
@@ -247,11 +248,83 @@ def add_voxel_layers_usd(builder: USDBuilder,
     return builder
 
 
+@ar_layer_export(VolumeLayerState, "Voxel", ARVoxelExportOptions, ("stl",), multiple=True)
+def add_voxel_layers_stl(builder: STLBuilder,
+                         viewer_state: Vispy3DVolumeViewerState,
+                         layer_states: Iterable[VolumeLayerState],
+                         options: Iterable[ARVoxelExportOptions],
+                         bounds: Optional[BoundsWithResolution] = None):
+
+    resolution = get_resolution(viewer_state)
+    bounds = bounds or xyz_bounds(viewer_state, with_resolution=True)
+    x_range = viewer_state.x_max - viewer_state.x_min
+    y_range = viewer_state.y_max - viewer_state.y_min
+    z_range = viewer_state.z_max - viewer_state.z_min
+    x_spacing = x_range / resolution
+    y_spacing = y_range / resolution
+    z_spacing = z_range / resolution
+    sides = (x_spacing, y_spacing, z_spacing)
+
+    world_bounds = xyz_bounds(viewer_state, with_resolution=False)
+    if viewer_state.native_aspect:
+        clip_transforms = clip_linear_transformations(world_bounds, clip_size=1)
+        clip_sides = [s * transform[0] for s, transform in zip(sides, clip_transforms)]
+        clip_sides = [clip_sides[1], clip_sides[2], clip_sides[0]]
+    else:
+        clip_sides = [2 / resolution for _ in range(3)]
+
+    triangles = rectangular_prism_triangulation()
+
+    opacity_factor = 1
+    occupied_voxels = {}
+    
+    for layer_state, option in zip(layer_states, options):
+        opacity_cutoff = clamp(option.opacity_cutoff, 0, 1)
+        data = frb_for_layer(viewer_state, layer_state, bounds)
+
+        isomin = isomin_for_layer(viewer_state, layer_state)
+        isomax = isomax_for_layer(viewer_state, layer_state)
+
+        data[~isfinite(data)] = isomin - 1
+
+        data = transpose(data, (1, 0, 2))
+
+        isorange = isomax - isomin
+        nonempty_indices = argwhere(data - isomin > 0)
+
+        color = layer_color(layer_state)
+        color_components = hex_to_components(color)
+
+        for indices in nonempty_indices:
+            value = data[tuple(indices)]
+            adjusted_opacity = clamped_opacity(layer_state.alpha * opacity_factor * (value - isomin) / isorange)
+            indices_tpl = tuple(indices)
+            if indices_tpl in occupied_voxels:
+                current_color = occupied_voxels[indices_tpl]
+                adjusted_a_color = color_components[:3] + [adjusted_opacity]
+                new_color = alpha_composite(adjusted_a_color, current_color)
+                occupied_voxels[indices_tpl] = new_color
+            elif adjusted_opacity >= opacity_cutoff:
+                occupied_voxels[indices_tpl] = color_components[:3] + [adjusted_opacity]
+
+    for indices, rgba in occupied_voxels.items():
+        if rgba[-1] < opacity_cutoff:
+            continue
+
+        center = tuple((index + 0.5) * side for index, side in zip(indices, clip_sides))
+        points = rectangular_prism_points(center, clip_sides)
+        builder.add_mesh(points, triangles)
+
+    return builder
+
+
 try:
     from glue_jupyter.ipyvolume.volume import VolumeLayerState as IPVVolumeLayerState
     ar_layer_export.add(IPVVolumeLayerState, "Voxel", ARVoxelExportOptions,
                         ("gltf", "glb"), True, add_voxel_layers_gltf)
     ar_layer_export.add(IPVVolumeLayerState, "Voxel", ARVoxelExportOptions,
                         ("usda", "usdc", "usdz"), True, add_voxel_layers_usd)
+    ar_layer_export.add(IPVVolumeLayerState, "Voxel", ARVoxelExportOptions,
+                        ("stl",), True, add_voxel_layers_stl)
 except ImportError:
     pass

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -277,7 +277,7 @@ def add_voxel_layers_stl(builder: STLBuilder,
 
     opacity_factor = 1
     occupied_voxels = {}
-    
+
     for layer_state, option in zip(layer_states, options):
         opacity_cutoff = clamp(option.opacity_cutoff, 0, 1)
         data = frb_for_layer(viewer_state, layer_state, bounds)

--- a/glue_ar/jupyter/tests/test_dialog.py
+++ b/glue_ar/jupyter/tests/test_dialog.py
@@ -55,6 +55,7 @@ class TestJupyterExportDialog(BaseExportDialogTest):
             {"text": "USDZ", "value": 2},
             {"text": "USDC", "value": 3},
             {"text": "USDA", "value": 4},
+            {"text": "STL", "value": 5},
         ]
         assert self.dialog.filetype_selected == 0
         assert set([item["text"] for item in self.dialog.method_items]) == {"Isosurface", "Voxel"}
@@ -76,8 +77,8 @@ class TestJupyterExportDialog(BaseExportDialogTest):
         state.filetype = "USDA"
         assert not self.dialog.show_compression
 
-        state.filetype = "glB"
-        assert self.dialog.show_compression
+        state.filetype = "STL"
+        assert not self.dialog.show_compression
 
         state.filetype = "glTF"
         assert self.dialog.show_compression

--- a/glue_ar/qt/export_tool.py
+++ b/glue_ar/qt/export_tool.py
@@ -56,7 +56,8 @@ class QtARExportTool(Tool):
                         layer.enabled and layer.state.visible]
         bounds = xyz_bounds(self.viewer.state, with_resolution=is_volume_viewer(self.viewer))
 
-        self._start_worker(export_viewer,
+        # self._start_worker(export_viewer,
+        export_viewer(
                            viewer_state=self.viewer.state,
                            layer_states=layer_states,
                            bounds=bounds,

--- a/glue_ar/qt/export_tool.py
+++ b/glue_ar/qt/export_tool.py
@@ -21,6 +21,7 @@ _FILETYPE_NAMES = {
     "usdz": "USDZ",
     "usdc": "USDC",
     "usda": "USDA",
+    "stl": "STL",
 }
 
 
@@ -56,8 +57,7 @@ class QtARExportTool(Tool):
                         layer.enabled and layer.state.visible]
         bounds = xyz_bounds(self.viewer.state, with_resolution=is_volume_viewer(self.viewer))
 
-        # self._start_worker(export_viewer,
-        export_viewer(
+        self._start_worker(export_viewer,
                            viewer_state=self.viewer.state,
                            layer_states=layer_states,
                            bounds=bounds,

--- a/glue_ar/qt/tests/test_dialog.py
+++ b/glue_ar/qt/tests/test_dialog.py
@@ -65,9 +65,9 @@ class TestQtExportDialog(BaseExportDialogTest):
         assert not ui.combosel_compression.isVisible()
         assert not ui.label_compression_message.isVisible()
 
-        state.filetype = "glB"
-        assert ui.combosel_compression.isVisible()
-        assert ui.label_compression_message.isVisible()
+        state.filetype = "STL"
+        assert not ui.combosel_compression.isVisible()
+        assert not ui.label_compression_message.isVisible()
 
         state.filetype = "glTF"
         assert ui.combosel_compression.isVisible()

--- a/glue_ar/qt/tests/test_tool_scatter.py
+++ b/glue_ar/qt/tests/test_tool_scatter.py
@@ -57,7 +57,8 @@ class TestScatterExportTool:
         assert len([subtool for subtool in tool.subtools if isinstance(subtool, QtARExportTool)]) == 1
 
     @pytest.mark.parametrize("extension,compression",
-                             product(("glB", "glTF", "USDA", "USDC", "USDZ", "STL"), ("None", "Draco", "Meshoptimizer")))
+                             product(("glB", "glTF", "USDA", "USDC", "USDZ", "STL"),
+                                     ("None", "Draco", "Meshoptimizer")))
     def test_tool_export_call(self, extension, compression):
         auto_accept = dialog_auto_accept_with_options(filetype=extension, compression=compression)
         with patch("qtpy.compat.getsavefilename") as fd, \

--- a/glue_ar/qt/tests/test_tool_scatter.py
+++ b/glue_ar/qt/tests/test_tool_scatter.py
@@ -57,7 +57,7 @@ class TestScatterExportTool:
         assert len([subtool for subtool in tool.subtools if isinstance(subtool, QtARExportTool)]) == 1
 
     @pytest.mark.parametrize("extension,compression",
-                             product(("glB", "glTF", "USDA", "USDC", "USDZ"), ("None", "Draco", "Meshoptimizer")))
+                             product(("glB", "glTF", "USDA", "USDC", "USDZ", "STL"), ("None", "Draco", "Meshoptimizer")))
     def test_tool_export_call(self, extension, compression):
         auto_accept = dialog_auto_accept_with_options(filetype=extension, compression=compression)
         with patch("qtpy.compat.getsavefilename") as fd, \

--- a/glue_ar/qt/tests/test_tool_volume.py
+++ b/glue_ar/qt/tests/test_tool_volume.py
@@ -62,7 +62,7 @@ class TestVolumeExportTool:
         assert len([subtool for subtool in tool.subtools if isinstance(subtool, QtARExportTool)]) == 1
 
     @pytest.mark.parametrize("extension,compression",
-                             product(("glB", "glTF", "USDA", "USDC", "USDZ"), ("None", "Draco", "Meshoptimizer")))
+                             product(("glB", "glTF", "USDA", "USDC", "USDZ", "STL"), ("None", "Draco", "Meshoptimizer")))
     def test_tool_export_call(self, extension, compression):
         auto_accept = dialog_auto_accept_with_options(filetype=extension, compression=compression)
         with patch("qtpy.compat.getsavefilename") as fd, \

--- a/glue_ar/qt/tests/test_tool_volume.py
+++ b/glue_ar/qt/tests/test_tool_volume.py
@@ -62,7 +62,8 @@ class TestVolumeExportTool:
         assert len([subtool for subtool in tool.subtools if isinstance(subtool, QtARExportTool)]) == 1
 
     @pytest.mark.parametrize("extension,compression",
-                             product(("glB", "glTF", "USDA", "USDC", "USDZ", "STL"), ("None", "Draco", "Meshoptimizer")))
+                             product(("glB", "glTF", "USDA", "USDC", "USDZ", "STL"),
+                                     ("None", "Draco", "Meshoptimizer")))
     def test_tool_export_call(self, extension, compression):
         auto_accept = dialog_auto_accept_with_options(filetype=extension, compression=compression)
         with patch("qtpy.compat.getsavefilename") as fd, \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ngrok
 pillow
 segno
 usd-core
+numpy-stl

--- a/setup.py
+++ b/setup.py
@@ -733,6 +733,7 @@ dependencies=[
     "gltflib",
     "glue-core",
     "glue-vispy-viewers",
+    "numpy-stl",
     "pillow",
     "PyMCubes",
     "usd-core",


### PR DESCRIPTION
This PR adds initial support for STL export, which resolves #66. This supports all three of our current export methods (scatter, isosurface, voxel).

Note that this does NOT include support for exporting MTL files - these STL exports are the meshes only. We can add support for STL materials in the future.