### PR TITLE
Improve export speed for USD scatter

### DIFF
--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -134,17 +134,17 @@ def add_scatter_layer_usd(
 
     # If we're in fixed-color mode, we can use one mesh for everything
     opacity = float(layer_state.alpha)
-    triangle_offset = 0
     if fixed_color:
         points = []
         tris = []
-        for point in data:
+        triangle_offset = 0
+        for i, point in enumerate(data):
             size = radius if fixed_size else sizes[i]
             pts = points_getter(point, size)
             points.append(pts)
             pt_triangles = offset_triangles(triangles, triangle_offset)
             triangle_offset += len(pts)
-            triangles.append(pt_triangles)
+            tris.append(pt_triangles)
 
         mesh_points = [pt for pts in points for pt in pts]
         mesh_triangles = [tri for sphere in tris for tri in sphere] 
@@ -156,11 +156,13 @@ def add_scatter_layer_usd(
     else:
         points_by_color = defaultdict(list)
         triangles_by_color = defaultdict(list)
-        for point, color in zip(data, colors):
+        triangle_offsets = defaultdict(int)
+        for i, point in enumerate(data):
+            color = colors[i]
             size = radius if fixed_size else sizes[i]
             pts = points_getter(point, size)
-            pt_triangles = offset_triangles(triangles, triangle_offset)
-            triangle_offset += len(pts)
+            pt_triangles = offset_triangles(triangles, triangle_offsets[color])
+            triangle_offsets[color] += len(pts)
             points_by_color[color].append(pts)
             triangles_by_color[color].append(pt_triangles)
 

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -16,7 +16,6 @@ from glue_ar.common.shapes import cone_triangles, cone_points, cylinder_points, 
                                   normalize, rectangular_prism_triangulation, sphere_triangles
 from glue_ar.utils import Viewer3DState, export_label_for_layer, iterable_has_nan, hex_to_components, \
                           layer_color, offset_triangles, xyz_for_layer, Bounds, NoneType
-from glue_ar.usd_utils import material_for_color
 
 try:
     from glue_jupyter.common.state3d import ViewerState3D
@@ -147,7 +146,7 @@ def add_scatter_layer_usd(
             tris.append(pt_triangles)
 
         mesh_points = [pt for pts in points for pt in pts]
-        mesh_triangles = [tri for sphere in tris for tri in sphere] 
+        mesh_triangles = [tri for sphere in tris for tri in sphere]
         builder.add_mesh(mesh_points,
                          mesh_triangles,
                          color=color_components,
@@ -169,7 +168,7 @@ def add_scatter_layer_usd(
         for color, points in points_by_color.items():
             tris = triangles_by_color[color]
             mesh_points = [pt for pts in points for pt in pts]
-            mesh_triangles = [tri for sphere in tris for tri in sphere] 
+            mesh_triangles = [tri for sphere in tris for tri in sphere]
             builder.add_mesh(mesh_points,
                              mesh_triangles,
                              color=color,

--- a/glue_ar/common/shapes.py
+++ b/glue_ar/common/shapes.py
@@ -4,7 +4,7 @@ from typing import Iterable, List, Tuple, Union
 
 from numpy import cross, pi
 
-from glue_ar.gltf_utils import offset_triangles
+from glue_ar.utils import offset_triangles
 
 __all__ = [
     "rectangular_prism_points",

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -1,7 +1,7 @@
 from sys import platform
 from tempfile import NamedTemporaryFile
 
-from pxr import Sdf, Usd
+from pxr import Usd
 import pytest
 
 from glue_ar.common.export import export_viewer

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -44,42 +44,33 @@ class TestVispyScatterUSD(BaseScatterTest):
         phi_resolution: int = getattr(options, "phi_resolution", 3)
         sphere_pts_count = sphere_points_count(theta_resolution=theta_resolution, phi_resolution=phi_resolution)
         sphere_tris_count = sphere_triangles_count(theta_resolution=theta_resolution, phi_resolution=phi_resolution)
-        expected_vert_cts = [3] * sphere_tris_count
+        expected_vert_cts = [3] * sphere_tris_count * self.n
 
         color_precision = 5
         color_components = [round(c / 255, color_precision) for c in hex_to_components(layer.state.color)]
 
-        # There should be 2n + 4 total prims:
-        # The xform and the mesh for each point -> 2 * n
+        # There should be 6 total prims:
+        # The xform and the mesh (single color means one mesh)
         # The top-level world prim
         # The light
         # The material
         # The PBR shader
-        assert iterator_count(stage.TraverseAll()) == 2 * self.n + 4
+        assert iterator_count(stage.TraverseAll()) == 6
 
-        original_point_mesh = None
-        for i in range(self.n):
-            point_mesh = stage.GetPrimAtPath(f"/world/xform_{identifier}_{i}/mesh_{identifier}_{i}")
-            assert point_mesh is not None
-            points = list(point_mesh.GetAttribute("points").Get())
-            assert len(points) == sphere_pts_count
-            vertex_counts = list(point_mesh.GetAttribute("faceVertexCounts").Get())
-            assert vertex_counts == expected_vert_cts
-            vertex_indices = list(point_mesh.GetAttribute("faceVertexIndices").Get())
-            assert len(vertex_indices) == sphere_tris_count * 3
+        point_mesh = stage.GetPrimAtPath(f"/world/xform_{identifier}_0/mesh_{identifier}_0")
+        assert point_mesh is not None
+        points = list(point_mesh.GetAttribute("points").Get())
+        assert len(points) == sphere_pts_count * self.n
+        vertex_counts = list(point_mesh.GetAttribute("faceVertexCounts").Get())
+        assert vertex_counts == expected_vert_cts
+        vertex_indices = list(point_mesh.GetAttribute("faceVertexIndices").Get())
+        assert len(vertex_indices) == sphere_tris_count * 3 * self.n
 
-            material = material_for_mesh(point_mesh)
-            pbr_shader = stage.GetPrimAtPath(f"{material.GetPath()}/PBRShader")
-            assert pbr_shader.GetAttribute("inputs:metallic").Get() == 0.0
-            assert pbr_shader.GetAttribute("inputs:roughness").Get() == 1.0
-            assert round(pbr_shader.GetAttribute("inputs:opacity").Get(), color_precision) == \
-                   round(layer.state.alpha, color_precision)
-            assert [round(c, color_precision) for c in pbr_shader.GetAttribute("inputs:diffuseColor").Get()] == \
-                   color_components
-
-            if i == 0:
-                original_point_mesh = point_mesh
-            else:
-                stack_top = point_mesh.GetPrimStack()[0]
-                assert stack_top.referenceList.prependedItems[0] == \
-                       Sdf.Reference(primPath=original_point_mesh.GetPath())
+        material = material_for_mesh(point_mesh)
+        pbr_shader = stage.GetPrimAtPath(f"{material.GetPath()}/PBRShader")
+        assert pbr_shader.GetAttribute("inputs:metallic").Get() == 0.0
+        assert pbr_shader.GetAttribute("inputs:roughness").Get() == 1.0
+        assert round(pbr_shader.GetAttribute("inputs:opacity").Get(), color_precision) == \
+               round(layer.state.alpha, color_precision)
+        assert [round(c, color_precision) for c in pbr_shader.GetAttribute("inputs:diffuseColor").Get()] == \
+               color_components

--- a/glue_ar/gltf_utils.py
+++ b/glue_ar/gltf_utils.py
@@ -8,7 +8,6 @@ __all__ = [
     "slope_intercept_between",
     "clip_linear_transformations",
     "bring_into_clip",
-    "offset_triangles",
     "create_material_for_color",
     "add_points_to_bytearray",
     "add_triangles_to_bytearray",
@@ -42,10 +41,6 @@ def clip_linear_transformations(bounds, clip_size=1):
 
 def bring_into_clip(points, transforms):
     return [tuple(transform[0] * c + transform[1] for transform, c in zip(transforms, pt)) for pt in points]
-
-
-def offset_triangles(triangle_indices, offset):
-    return [tuple(idx + offset for idx in triangle) for triangle in triangle_indices]
 
 
 def create_material_for_color(

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -25,6 +25,20 @@ try:
 except ImportError:
     NoneType = type(None)
 
+
+__all__ = [
+    "NoneType", "PACKAGE_DIR", "AR_ICON", "RESOURCES_DIR", "data_count",
+    "export_label_for_layer", "layers_to_export", "isomin_for_layer",
+    "isomax_for_layer", "xyz_bounds", "bounds_3d_from_layers",
+    "slope_intercept_between", "layer_color", "bring_into_clip",
+    "mask_for_bounds", "xyz_for_layer", "hex_to_components",
+    "unique_id", "alpha_composite", "data_for_layer", "frb_for_layer",
+    "ndarray_has_nan", "iterable_has_nan", "iterator_count",
+    "is_volume_viewer", "get_resolution", "clamp", "clamped_opacity",
+    "binned_opacity", "offset_triangles",
+]
+
+
 PACKAGE_DIR = dirname(abspath(__file__))
 AR_ICON = abspath(join(dirname(__file__), "ar.png"))
 RESOURCES_DIR = join(PACKAGE_DIR, "resources")
@@ -298,3 +312,7 @@ def clamped_opacity(opacity: float) -> float:
 
 def binned_opacity(raw_opacity: float, resolution: float) -> float:
     return clamped_opacity(round(raw_opacity / resolution) * resolution)
+
+
+def offset_triangles(triangle_indices, offset):
+    return [tuple(idx + offset for idx in triangle) for triangle in triangle_indices]


### PR DESCRIPTION
This PR resolves #78. This PR implements the suggestion described in that issue. This leads to noticeably faster export times in my experience, without a significant impact on the file size.