### PR TITLE
Let user select whether or not to export model-viewer HTML with GL export

### DIFF
--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -40,7 +40,8 @@ def export_viewer(viewer_state: Vispy3DViewerState,
                   bounds: Union[Bounds, BoundsWithResolution],
                   state_dictionary: Dict[str, Tuple[str, State]],
                   filepath: str,
-                  compression: Optional[str]):
+                  compression: Optional[str] = "None",
+                  model_viewer: bool = False):
 
     base, ext = splitext(filepath)
     ext = ext[1:]
@@ -71,8 +72,9 @@ def export_viewer(viewer_state: Vispy3DViewerState,
     if ext in ("gltf", "glb"):
         if (compression is not None) and (compression != "None"):
             compress_gl(filepath, method=compression)
-        mv_path = f"{base}{extsep}html"
-        export_modelviewer(mv_path, filepath, viewer_state.title)
+        if model_viewer:
+            mv_path = f"{base}{extsep}html"
+            export_modelviewer(mv_path, filepath, viewer_state.title)
 
 
 def compress_gltf_pipeline(filepath: str):

--- a/glue_ar/common/export_state.py
+++ b/glue_ar/common/export_state.py
@@ -1,4 +1,4 @@
-from echo import SelectionCallbackProperty
+from echo import CallbackProperty, SelectionCallbackProperty
 from glue.core.data_combo_helper import ComboHelper
 from glue.core.state_objects import State
 from glue_vispy_viewers.common.layer_state import LayerState
@@ -17,6 +17,7 @@ class ARExportDialogState(State):
     layer = SelectionCallbackProperty()
     compression = SelectionCallbackProperty()
     method = SelectionCallbackProperty()
+    modelviewer = CallbackProperty(True)
 
     def __init__(self, layers: Iterable[LayerState]):
 

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -86,6 +86,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         link_glue_choices(self, self.state, 'compression')
         link_glue_choices(self, self.state, 'filetype')
         link_glue_choices(self, self.state, 'method')
+        link((self, 'modelviewer'), (self.state, 'modelviewer'))
 
         self.dialog_open = display
         self.on_cancel = on_cancel

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -68,6 +68,9 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
     layer_layout = traitlets.Instance(v.Container).tag(sync=True, **widget_serialization)
     has_layer_options = traitlets.Bool().tag(sync=True)
 
+    modelviewer = traitlets.Bool(True).tag(sync=True)
+    show_modelviewer = traitlets.Bool(True).tag(sync=True)
+
     def __init__(self,
                  viewer: Viewer,
                  display: Optional[bool] = False,
@@ -112,6 +115,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         super()._on_filetype_change(filetype)
         gl = filetype.lower() in ("gltf", "glb")
         self.show_compression = gl
+        self.show_modelviewer = gl
 
     def widgets_for_property(self,
                              instance: HasCallbackProperties,

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -47,15 +47,16 @@
           v-model="compression_selected"
         />
         <v-row>
-          <v-spacer></v-spacer>
-          <v-btn class="mx-2" color="error" @click="cancel_dialog">Cancel</v-btn>
-          <v-btn class="mx-2" color="success" @click="export_viewer">Export</v-btn>
-        </v-row>
-        <v-row>
           <v-checkbox
             v-if="show_modelviewer"
             v-model="modelviewer"
+            label="Export model-viewer HTML"
           />
+        </v-row>
+        <v-row>
+          <v-spacer></v-spacer>
+          <v-btn class="mx-2" color="error" @click="cancel_dialog">Cancel</v-btn>
+          <v-btn class="mx-2" color="success" @click="export_viewer">Export</v-btn>
         </v-row>
       </v-container>
     </v-card>

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -51,6 +51,12 @@
           <v-btn class="mx-2" color="error" @click="cancel_dialog">Cancel</v-btn>
           <v-btn class="mx-2" color="success" @click="export_viewer">Export</v-btn>
         </v-row>
+        <v-row>
+          <v-checkbox
+            v-if="show_modelviewer"
+            v-model="modelviewer"
+          />
+        </v-row>
       </v-container>
     </v-card>
   </v-dialog>

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -116,4 +116,5 @@ class JupyterARExportTool(Tool):
                       bounds=bounds,
                       state_dictionary=state_dict,
                       filepath=filepath,
-                      compression=self.export_dialog.state.compression)
+                      compression=self.export_dialog.state.compression,
+                      model_viewer=self.export_dialog.state.modelviewer)

--- a/glue_ar/jupyter/tests/test_dialog.py
+++ b/glue_ar/jupyter/tests/test_dialog.py
@@ -67,21 +67,27 @@ class TestJupyterExportDialog(BaseExportDialogTest):
 
         state.filetype = "USDC"
         assert not self.dialog.show_compression
+        assert not self.dialog.show_modelviewer
 
         state.filetype = "USDA"
         assert not self.dialog.show_compression
+        assert not self.dialog.show_modelviewer
 
         state.filetype = "glTF"
         assert self.dialog.show_compression
+        assert self.dialog.show_modelviewer
 
         state.filetype = "USDA"
         assert not self.dialog.show_compression
+        assert not self.dialog.show_modelviewer
 
         state.filetype = "STL"
         assert not self.dialog.show_compression
+        assert not self.dialog.show_modelviewer
 
         state.filetype = "glTF"
         assert self.dialog.show_compression
+        assert self.dialog.show_modelviewer
 
     def test_widgets_for_property(self):
         state = DummyState()

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -100,6 +100,7 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
         gl = filetype.lower() in ("gltf", "glb")
         self.ui.combosel_compression.setVisible(gl)
         self.ui.label_compression_message.setVisible(gl)
+        self.ui.bool_modelviewer.setVisible(gl)
 
     def _on_method_change(self, method_name: str):
         super()._on_method_change(method_name)

--- a/glue_ar/qt/export_dialog.ui
+++ b/glue_ar/qt/export_dialog.ui
@@ -14,10 +14,71 @@
    <string>Export 3D File</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Layer Options&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <widget class="QComboBox" name="combosel_compression"/>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="0" colspan="2">
     <layout class="QFormLayout" name="layer_layout"/>
    </item>
-   <item row="16" column="0" colspan="2">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_settings_message">
+     <property name="text">
+      <string>Select export options</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_filetype_message">
+     <property name="text">
+      <string>Filetype</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
+    <widget class="QComboBox" name="combosel_filetype"/>
+   </item>
+   <item row="6" column="1">
+    <widget class="QComboBox" name="combosel_method"/>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QListWidget" name="listsel_layer"/>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;File Options&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_method">
+     <property name="text">
+      <string>Export method:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_compression_message">
+     <property name="text">
+      <string>Compression method</string>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="0" colspan="2">
     <widget class="QWidget" name="widget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
@@ -56,64 +117,13 @@
      </layout>
     </widget>
    </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_filetype_message">
+   <item row="16" column="0" colspan="2">
+    <widget class="QCheckBox" name="bool_modelviewer">
      <property name="text">
-      <string>Filetype</string>
+      <string>Export model-viewer HTML</string>
      </property>
-    </widget>
-   </item>
-   <item row="14" column="1">
-    <widget class="QComboBox" name="combosel_compression"/>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label_compression_message">
-     <property name="text">
-      <string>Compression method</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_method">
-     <property name="text">
-      <string>Export method:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="1">
-    <widget class="QComboBox" name="combosel_filetype"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_settings_message">
-     <property name="text">
-      <string>Select export options</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QComboBox" name="combosel_method"/>
-   </item>
-   <item row="11" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;File Options&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QListWidget" name="listsel_layer"/>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Layer Options&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/glue_ar/qt/export_tool.py
+++ b/glue_ar/qt/export_tool.py
@@ -63,7 +63,8 @@ class QtARExportTool(Tool):
                            bounds=bounds,
                            state_dictionary=dialog.state_dictionary,
                            filepath=export_path,
-                           compression=dialog.state.compression)
+                           compression=dialog.state.compression,
+                           model_viewer=dialog.state.modelviewer)
 
     def _start_worker(self, exporter, **kwargs):
         _, ext = splitext(kwargs["filepath"])

--- a/glue_ar/qt/tests/test_tool_scatter.py
+++ b/glue_ar/qt/tests/test_tool_scatter.py
@@ -88,6 +88,7 @@ class TestScatterExportTool:
             assert kwargs["bounds"] == bounds
             assert kwargs["filepath"] == filepath
             assert kwargs["compression"] == compression
+            assert kwargs["model_viewer"]
             state_dict = kwargs["state_dictionary"]
             assert tuple(state_dict.keys()) == ("Scatter Data 1", "Scatter Data 2")
             for value in state_dict.values():


### PR DESCRIPTION
Currently we automatically export a model-viewer HTML page any time the user exports a glTF or glB file. This PR makes the optional via a checkbox in the export dialog.
