### PR TITLE
Add support for axis stretches

### DIFF
--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -12,8 +12,8 @@ from glue_ar.common.stl_builder import STLBuilder
 from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.volume_export_options import ARIsosurfaceExportOptions
 from glue_ar.gltf_utils import add_points_to_bytearray, add_triangles_to_bytearray, \
-                               clip_linear_transformations, index_mins, index_maxes
-from glue_ar.utils import BoundsWithResolution, frb_for_layer, hex_to_components, isomin_for_layer, \
+                               index_mins, index_maxes
+from glue_ar.utils import BoundsWithResolution, clip_linear_transformations, frb_for_layer, hex_to_components, isomin_for_layer, \
                           isomax_for_layer, layer_color
 
 

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -36,6 +36,8 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
     color_components = hex_to_components(color)
     builder.add_material(color_components, opacity=opacity)
     sides = clip_sides(viewer_state, clip_size=1)
+    print("Sides:")
+    print(sides)
 
     for level in levels[1:]:
         barr = bytearray()

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -37,8 +37,6 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
     builder.add_material(color_components, opacity=opacity)
     sides = clip_sides(viewer_state, clip_size=1)
     sides = tuple(sides[i] for i in (2, 1, 0))
-    print("Sides:")
-    print(sides)
 
     for level in levels[1:]:
         barr = bytearray()

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -36,6 +36,7 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
     color_components = hex_to_components(color)
     builder.add_material(color_components, opacity=opacity)
     sides = clip_sides(viewer_state, clip_size=1)
+    sides = tuple(sides[i] for i in (2, 1, 0))
     print("Sides:")
     print(sides)
 
@@ -121,6 +122,7 @@ def add_isosurface_layer_usd(
     color = layer_color(layer_state)
     color_components = tuple(hex_to_components(color))
     sides = clip_sides(viewer_state, clip_size=1)
+    sides = tuple(sides[i] for i in (2, 1, 0))
 
     for i, level in enumerate(levels[1:]):
         alpha = (3 * i + isosurface_count) / (4 * isosurface_count) * opacity
@@ -152,6 +154,7 @@ def add_isosurface_layer_stl(
     isosurface_count = int(options.isosurface_count)
     levels = linspace(isomin, isomax, isosurface_count)
     sides = clip_sides(viewer_state, clip_size=1)
+    sides = tuple(sides[i] for i in (2, 1, 0))
 
     for i, level in enumerate(levels[1:]):
         # alpha = (3 * i + isosurface_count) / (4 * isosurface_count) * opacity

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -13,7 +13,7 @@ from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.volume_export_options import ARIsosurfaceExportOptions
 from glue_ar.gltf_utils import add_points_to_bytearray, add_triangles_to_bytearray, \
                                index_mins, index_maxes
-from glue_ar.utils import BoundsWithResolution, clip_linear_transformations, frb_for_layer, hex_to_components, isomin_for_layer, \
+from glue_ar.utils import BoundsWithResolution, clip_sides, frb_for_layer, hex_to_components, isomin_for_layer, \
                           isomax_for_layer, layer_color
 
 
@@ -35,25 +35,7 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
     color = layer_color(layer_state)
     color_components = hex_to_components(color)
     builder.add_material(color_components, opacity=opacity)
-
-    world_bounds = (
-        (viewer_state.y_min, viewer_state.y_max),
-        (viewer_state.x_min, viewer_state.x_max),
-        (viewer_state.z_min, viewer_state.z_max),
-    )
-    resolution = getattr(viewer_state, 'resolution', None) or getattr(layer_state, 'max_resolution')
-    x_range = viewer_state.x_max - viewer_state.x_min
-    y_range = viewer_state.y_max - viewer_state.y_min
-    z_range = viewer_state.z_max - viewer_state.z_min
-    x_spacing = x_range / resolution
-    y_spacing = y_range / resolution
-    z_spacing = z_range / resolution
-    sides = (z_spacing, x_spacing, y_spacing)
-    if viewer_state.native_aspect:
-        clip_transforms = clip_linear_transformations(world_bounds, clip_size=1)
-        clip_sides = [s * transform[0] for s, transform in zip(sides, clip_transforms)]
-    else:
-        clip_sides = [2 / resolution for _ in range(3)]
+    sides = clip_sides(viewer_state, clip_size=1)
 
     for level in levels[1:]:
         barr = bytearray()
@@ -63,7 +45,7 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
         if len(points) == 0:
             continue
 
-        points = [tuple((-1 + (index + 0.5) * side) for index, side in zip(pt, clip_sides)) for pt in points]
+        points = [tuple((-1 + (index + 0.5) * side) for index, side in zip(pt, sides)) for pt in points]
         points = [[p[1], p[0], p[2]] for p in points]
         add_points_to_bytearray(barr, points)
         point_len = len(barr)
@@ -136,25 +118,7 @@ def add_isosurface_layer_usd(
     opacity = layer_state.alpha
     color = layer_color(layer_state)
     color_components = tuple(hex_to_components(color))
-
-    world_bounds = (
-        (viewer_state.y_min, viewer_state.y_max),
-        (viewer_state.x_min, viewer_state.x_max),
-        (viewer_state.z_min, viewer_state.z_max),
-    )
-    resolution = getattr(viewer_state, 'resolution', None) or getattr(layer_state, 'max_resolution')
-    x_range = viewer_state.x_max - viewer_state.x_min
-    y_range = viewer_state.y_max - viewer_state.y_min
-    z_range = viewer_state.z_max - viewer_state.z_min
-    x_spacing = x_range / resolution
-    y_spacing = y_range / resolution
-    z_spacing = z_range / resolution
-    sides = (z_spacing, x_spacing, y_spacing)
-    if viewer_state.native_aspect:
-        clip_transforms = clip_linear_transformations(world_bounds, clip_size=1)
-        clip_sides = [s * transform[0] for s, transform in zip(sides, clip_transforms)]
-    else:
-        clip_sides = [2 / resolution for _ in range(3)]
+    sides = clip_sides(viewer_state, clip_size=1)
 
     for i, level in enumerate(levels[1:]):
         alpha = (3 * i + isosurface_count) / (4 * isosurface_count) * opacity
@@ -162,7 +126,7 @@ def add_isosurface_layer_usd(
         if len(points) == 0:
             continue
 
-        points = [tuple((-1 + (index + 0.5) * side) for index, side in zip(pt, clip_sides)) for pt in points]
+        points = [tuple((-1 + (index + 0.5) * side) for index, side in zip(pt, sides)) for pt in points]
         points = [[p[1], p[0], p[2]] for p in points]
         builder.add_mesh(points, triangles, color_components, alpha)
 
@@ -185,25 +149,7 @@ def add_isosurface_layer_stl(
 
     isosurface_count = int(options.isosurface_count)
     levels = linspace(isomin, isomax, isosurface_count)
-
-    world_bounds = (
-        (viewer_state.y_min, viewer_state.y_max),
-        (viewer_state.x_min, viewer_state.x_max),
-        (viewer_state.z_min, viewer_state.z_max),
-    )
-    resolution = getattr(viewer_state, 'resolution', None) or getattr(layer_state, 'max_resolution')
-    x_range = viewer_state.x_max - viewer_state.x_min
-    y_range = viewer_state.y_max - viewer_state.y_min
-    z_range = viewer_state.z_max - viewer_state.z_min
-    x_spacing = x_range / resolution
-    y_spacing = y_range / resolution
-    z_spacing = z_range / resolution
-    sides = (z_spacing, x_spacing, y_spacing)
-    if viewer_state.native_aspect:
-        clip_transforms = clip_linear_transformations(world_bounds, clip_size=1)
-        clip_sides = [s * transform[0] for s, transform in zip(sides, clip_transforms)]
-    else:
-        clip_sides = [2 / resolution for _ in range(3)]
+    sides = clip_sides(viewer_state, clip_size=1)
 
     for i, level in enumerate(levels[1:]):
         # alpha = (3 * i + isosurface_count) / (4 * isosurface_count) * opacity
@@ -211,7 +157,7 @@ def add_isosurface_layer_stl(
         if len(points) == 0:
             continue
 
-        points = [tuple((-1 + (index + 0.5) * side) for index, side in zip(pt, clip_sides)) for pt in points]
+        points = [tuple((-1 + (index + 0.5) * side) for index, side in zip(pt, sides)) for pt in points]
         points = [[p[1], p[0], p[2]] for p in points]
         builder.add_mesh(points, triangles)
 

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -31,6 +31,9 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
     bounds = bounds or xyz_bounds(viewer_state, with_resolution=True)
     sides = clip_sides(viewer_state, clip_size=1)
+    print("Sides before reindexing", sides)
+    sides = tuple(sides[i] for i in (1, 2, 0))
+    print("Sides", sides)
 
     point_index = 0
     points_barr = bytearray()
@@ -158,6 +161,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
 
     bounds = bounds or xyz_bounds(viewer_state, with_resolution=True)
     sides = clip_sides(viewer_state, clip_size=1)
+    sides = tuple(sides[i] for i in (1, 2, 0))
 
     triangles = rectangular_prism_triangulation()
 
@@ -228,6 +232,7 @@ def add_voxel_layers_stl(builder: STLBuilder,
 
     bounds = bounds or xyz_bounds(viewer_state, with_resolution=True)
     sides = clip_sides(viewer_state, clip_size=1)
+    sides = tuple(sides[i] for i in (1, 2, 0))
 
     triangles = rectangular_prism_triangulation()
 

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -31,9 +31,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
     bounds = bounds or xyz_bounds(viewer_state, with_resolution=True)
     sides = clip_sides(viewer_state, clip_size=1)
-    print("Sides before reindexing", sides)
     sides = tuple(sides[i] for i in (1, 2, 0))
-    print("Sides", sides)
 
     point_index = 0
     points_barr = bytearray()

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -1,4 +1,3 @@
-from glue_vispy_viewers.common import layer_state
 from glue_vispy_viewers.volume.viewer_state import Vispy3DVolumeViewerState
 from numpy import isfinite, argwhere, transpose
 from typing import Iterable, Optional

--- a/glue_ar/gltf_utils.py
+++ b/glue_ar/gltf_utils.py
@@ -5,9 +5,6 @@ from typing import Callable, Iterable, List, Optional, Type, TypeVar, Union
 from gltflib import Material, PBRMetallicRoughness
 
 __all__ = [
-    "slope_intercept_between",
-    "clip_linear_transformations",
-    "bring_into_clip",
     "create_material_for_color",
     "add_points_to_bytearray",
     "add_triangles_to_bytearray",
@@ -20,27 +17,6 @@ GLTF_COMPRESSION_EXTENSIONS = {
     "draco": "KHR_draco_mesh_compression",
     "meshoptimizer": "EXT_meshopt_compression",
 }
-
-
-def slope_intercept_between(a, b):
-    slope = (b[1] - a[1]) / (b[0] - a[0])
-    intercept = b[1] - slope * b[0]
-    return slope, intercept
-
-
-def clip_linear_transformations(bounds, clip_size=1):
-    ranges = [abs(bds[1] - bds[0]) for bds in bounds]
-    max_range = max(ranges)
-    line_data = []
-    for bds, rg in zip(bounds, ranges):
-        frac = rg / max_range
-        target = frac * clip_size
-        line_data.append(slope_intercept_between((bds[0], -target), (bds[1], target)))
-    return line_data
-
-
-def bring_into_clip(points, transforms):
-    return [tuple(transform[0] * c + transform[1] for transform, c in zip(transforms, pt)) for pt in points]
 
 
 def create_material_for_color(

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -149,14 +149,10 @@ def clip_linear_transformations(bounds: Union[Bounds, BoundsWithResolution],
                                 stretches: Tuple[float, float, float] = (1.0, 1.0, 1.0)):
     ranges = [abs(bds[1] - bds[0]) for bds in bounds]
     max_side = max(rg * stretch for rg, stretch in zip(ranges, stretches))
-    print("Max side")
-    print(max_side)
     line_data = []
     for bds, rg, stretch in zip(bounds, ranges, stretches):
         frac = rg * stretch / max_side 
         target = frac * clip_size
-        print("Target")
-        print(target)
         line_data.append(slope_intercept_between((bds[0], -target), (bds[1], target)))
     return line_data
 
@@ -188,8 +184,6 @@ def clip_sides(viewer_state: Viewer3DState,
     y_spacing = y_range / resolution
     z_spacing = z_range / resolution
     sides = (x_spacing, y_spacing, z_spacing)
-    print("Sides in clip_sides:")
-    print(sides)
     if viewer_state.native_aspect:
         clip_transforms = clip_linear_transformations(bounds,
                                                       clip_size=clip_size,
@@ -286,7 +280,6 @@ def frb_for_layer(viewer_state: ViewerState,
                   bounds: BoundsWithResolution) -> ndarray:
 
     bounds = list(reversed(bounds))
-    print(bounds)
     data = data_for_layer(layer_or_state)
     layer_state = layer_or_state if isinstance(layer_or_state, LayerState) else layer_or_state.state
     is_data_layer = data is layer_or_state.layer

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -138,7 +138,8 @@ def bounds_3d_from_layers(viewer_state: Viewer3DState,
     return bounds
 
 
-def slope_intercept_between(a: Union[List[float], Tuple[float,float]], b: Union[List[float], Tuple[float,float]]) -> Tuple[float, float]:
+def slope_intercept_between(a: Union[List[float], Tuple[float, float]],
+                            b: Union[List[float], Tuple[float, float]]) -> Tuple[float, float]:
     slope = (b[1] - a[1]) / (b[0] - a[0])
     intercept = b[1] - slope * b[0]
     return slope, intercept
@@ -151,7 +152,7 @@ def clip_linear_transformations(bounds: Union[Bounds, BoundsWithResolution],
     max_side = max(rg * stretch for rg, stretch in zip(ranges, stretches))
     line_data = []
     for bds, rg, stretch in zip(bounds, ranges, stretches):
-        frac = rg * stretch / max_side 
+        frac = rg * stretch / max_side
         target = frac * clip_size
         line_data.append(slope_intercept_between((bds[0], -target), (bds[1], target)))
     return line_data
@@ -168,7 +169,7 @@ def layer_color(layer_state: LayerState) -> str:
 
 
 def clip_sides(viewer_state: Viewer3DState,
-               clip_size: float = 1.0) -> Tuple[float,float,float]:
+               clip_size: float = 1.0) -> Tuple[float, float, float]:
 
     stretches = tuple(
         getattr(viewer_state, f"{axis}_stretch", 1.0)
@@ -176,7 +177,7 @@ def clip_sides(viewer_state: Viewer3DState,
     )
 
     bounds = xyz_bounds(viewer_state, with_resolution=False)
-    resolution = get_resolution(viewer_state) 
+    resolution = get_resolution(viewer_state)
     x_range = viewer_state.x_max - viewer_state.x_min
     y_range = viewer_state.y_max - viewer_state.y_min
     z_range = viewer_state.z_max - viewer_state.z_min
@@ -198,12 +199,12 @@ def bring_into_clip(data,
                     bounds: Union[Bounds, BoundsWithResolution],
                     clip_size: float = 1.0,
                     preserve_aspect: bool = True,
-                    stretches: Tuple[float,float,float] = (1.0, 1.0, 1.0)
-):
+                    stretches: Tuple[float, float, float] = (1.0, 1.0, 1.0)):
     if preserve_aspect:
         line_data = clip_linear_transformations(bounds=bounds, clip_size=clip_size, stretches=stretches)
     else:
-        line_data = [slope_intercept_between([bds[0], -stretch], [bds[1], stretch]) for bds, stretch in zip(bounds, stretches)]
+        line_data = [slope_intercept_between([bds[0], -stretch], [bds[1], stretch])
+                     for bds, stretch in zip(bounds, stretches)]
 
     scaled = [[m * d + b for d in data[idx]] for idx, (m, b) in enumerate(line_data)]
 
@@ -337,8 +338,9 @@ def get_resolution(viewer_state: Viewer3DState) -> int:
     try:
         from glue_jupyter.common.state3d import VolumeViewerState
         if isinstance(viewer_state, VolumeViewerState):
-            return max((resolution for state in viewer_state.layers if (resolution := getattr(state, "max_resolution", None)) is not None),
-                        default=256)
+            return max((resolution for state in viewer_state.layers
+                        if (resolution := getattr(state, "max_resolution", None)) is not None),
+                       default=256)
     except ImportError:
         pass
 


### PR DESCRIPTION
Currently plugin exports don't respect the axis stretch values of the viewer state. This PR adds support for stretches, and generally cleans up the functions related to putting the coordinates of the exported data into clip space.

The current approach of the plugin is to do the following: in native aspect mode, we make the largest coordinate range to (-1, 1) and others to the appropriate fraction. In non-native aspect mode, every range is mapped to (-1, 1).

With this PR, in native aspect mode we instead find the max of (range * stretch) across coordinates, which gets mapped to (-1, 1), and map other axis to range * stretch / max(range * stretch). And in non-native aspect mode, we map the range that's maximally stretched to (-1,1), and the others to the appropriate fraction.
