### PR TITLE
Use sliders for numerical values and combine resolutions

### DIFF
--- a/glue_ar/common/scatter_export_options.py
+++ b/glue_ar/common/scatter_export_options.py
@@ -6,9 +6,7 @@ __all__ = ["ARVispyScatterExportOptions"]
 
 
 class ARVispyScatterExportOptions(State):
-
-    theta_resolution = CallbackProperty(10)
-    phi_resolution = CallbackProperty(10)
+    resolution = CallbackProperty(10)
 
 
 class ARIpyvolumeScatterExportOptions(State):

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -350,8 +350,9 @@ def add_vispy_scatter_layer_gltf(builder: GLTFBuilder,
                                  bounds: Bounds,
                                  clip_to_bounds: bool = True):
 
-    theta_resolution = int(options.theta_resolution)
-    phi_resolution = int(options.phi_resolution)
+    resolution = int(options.resolution)
+    theta_resolution = resolution
+    phi_resolution = resolution
     triangles = sphere_triangles(theta_resolution=theta_resolution,
                                  phi_resolution=phi_resolution)
 

--- a/glue_ar/common/scatter_stl.py
+++ b/glue_ar/common/scatter_stl.py
@@ -59,8 +59,9 @@ def add_vispy_scatter_layer_stl(builder: STLBuilder,
                                 bounds: Bounds,
                                 clip_to_bounds: bool = True):
 
-    theta_resolution = int(options.theta_resolution)
-    phi_resolution = int(options.phi_resolution)
+    resolution = int(options.resolution)
+    theta_resolution = resolution
+    phi_resolution = resolution
     triangles = sphere_triangles(theta_resolution=theta_resolution,
                                  phi_resolution=phi_resolution)
 

--- a/glue_ar/common/scatter_usd.py
+++ b/glue_ar/common/scatter_usd.py
@@ -195,8 +195,9 @@ def add_vispy_scatter_layer_usd(builder: USDBuilder,
                                 bounds: Bounds,
                                 clip_to_bounds: bool = True):
 
-    theta_resolution = int(options.theta_resolution)
-    phi_resolution = int(options.phi_resolution)
+    resolution = int(options.resolution)
+    theta_resolution = resolution
+    phi_resolution = resolution
     triangles = sphere_triangles(theta_resolution=theta_resolution,
                                  phi_resolution=phi_resolution)
 

--- a/glue_ar/common/tests/test_base_dialog.py
+++ b/glue_ar/common/tests/test_base_dialog.py
@@ -9,8 +9,8 @@ from numpy import arange, ones
 
 
 class DummyState(State):
-    cb_int = CallbackProperty(0)
-    cb_float = CallbackProperty(1.7)
+    cb_int = CallbackProperty(2)
+    cb_float = CallbackProperty(0.7)
     cb_bool = CallbackProperty(False)
 
 

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -62,8 +62,8 @@ class TestScatterGLTF(BaseScatterTest):
 
         # TODO: 3 is the value for ipyvolume's diamond, which is the ipv default
         # But we should make this more robust
-        theta_resolution: int = getattr(options, "theta_resolution", 3)
-        phi_resolution: int = getattr(options, "phi_resolution", 3)
+        theta_resolution: int = getattr(options, "resolution", 3)
+        phi_resolution: int = getattr(options, "resolution", 3)
         triangles_count = sphere_triangles_count(theta_resolution=theta_resolution,
                                                  phi_resolution=phi_resolution)
         points_count = sphere_points_count(theta_resolution=theta_resolution,

--- a/glue_ar/common/tests/test_scatter_stl.py
+++ b/glue_ar/common/tests/test_scatter_stl.py
@@ -50,8 +50,8 @@ class TestScatterSTL(BaseScatterTest):
 
         # TODO: 3 is the value for ipyvolume's diamond, which is the ipv default
         # But we should make this more robust
-        theta_resolution: int = getattr(options, "theta_resolution", 3)
-        phi_resolution: int = getattr(options, "phi_resolution", 3)
+        theta_resolution: int = getattr(options, "resolution", 3)
+        phi_resolution: int = getattr(options, "resolution", 3)
         points_count = sphere_points_count(theta_resolution, phi_resolution)
         triangle_count = sphere_triangles_count(theta_resolution, phi_resolution)
         for index in range(self.data1.size):

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -40,8 +40,8 @@ class TestVispyScatterUSD(BaseScatterTest):
         _, options = self.state_dictionary[label]
 
         # The default ipyvolume geometry type is diamond
-        theta_resolution: int = getattr(options, "theta_resolution", 3)
-        phi_resolution: int = getattr(options, "phi_resolution", 3)
+        theta_resolution: int = getattr(options, "resolution", 3)
+        phi_resolution: int = getattr(options, "resolution", 3)
         sphere_pts_count = sphere_points_count(theta_resolution=theta_resolution, phi_resolution=phi_resolution)
         sphere_tris_count = sphere_triangles_count(theta_resolution=theta_resolution, phi_resolution=phi_resolution)
         expected_vert_cts = [3] * sphere_tris_count * self.n

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -4,47 +4,13 @@ from ipywidgets import DOMWidget, widget_serialization
 import traitlets
 from typing import Callable, List, Optional
 
-from echo import HasCallbackProperties
+from echo import HasCallbackProperties, add_callback
 from glue.core.state_objects import State
 from glue.viewers.common.viewer import Viewer
 from glue_jupyter.link import link
 from glue_jupyter.vuetify_helpers import link_glue_choices
 
 from glue_ar.common.export_dialog_base import ARExportDialogBase
-
-
-# Based on https://github.com/widgetti/ipyvuetify/issues/241
-class NumberField(v.VuetifyTemplate):
-    label = traitlets.Unicode().tag(sync=True)
-    value = traitlets.Unicode().tag(sync=True)
-
-    temp_error = traitlets.Unicode(allow_none=True, default_value=None).tag(sync=True)
-
-    def __init__(self, type, label, error_message, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.number_type = type
-        self.label = label
-        self.error_message = error_message
-
-    @traitlets.default("template")
-    def _template(self):
-        return """
-            <v-text-field
-              :label="label"
-              type="number"
-              v-model="value"
-              @change="temp_rule"
-              :rules="[temp_error]"
-            >
-            </v-text-field>
-        """
-
-    def vue_temp_rule(self, value):
-        self.temp_error = None
-        try:
-            self.number_type(value)
-        except ValueError:
-            self.temp_error = self.error_message
 
 
 class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
@@ -103,7 +69,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         for property, _ in state.iter_callback_properties():
             name = self.display_name(property)
             widgets.extend(self.widgets_for_property(state, property, name))
-        self.input_widgets = [w for w in widgets if isinstance(w, NumberField)]
+        self.input_widgets = [w for w in widgets if isinstance(w, v.Slider)]
         self.layer_layout = v.Container(children=widgets, px_0=True, py_0=True)
         self.has_layer_options = len(self.layer_layout.children) > 0
 
@@ -130,12 +96,21 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
             link((instance, property), (widget, 'value'))
             return [widget]
         elif t in (int, float):
-            name = "integer" if t is int else "number"
-            widget = NumberField(type=t, label=display_name, error_message=f"You must enter a valid {name}")
+            step = 0.01 if t is float else 1
+            min = step
+            max = min * 100
+            widget = v.Slider(min=min,
+                              max=max,
+                              step=step,
+                              label=display_name,
+                              thumb_label=f"{value:g}")
             link((instance, property),
-                 (widget, 'value'),
-                 lambda value: str(value),
-                 lambda text: t(text))
+                 (widget, 'value'))
+
+            def update_label(value):
+                widget.thumb_label = f"{value:g}"
+            add_callback(instance, property, update_label)
+
             return [widget]
         else:
             return []
@@ -147,7 +122,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
             self.on_cancel()
 
     def vue_export_viewer(self, *args):
-        okay = all(widget.temp_error is None for widget in self.input_widgets)
+        okay = all(not widget.error for widget in self.input_widgets)
         if not okay:
             return
         self.dialog_open = False

--- a/glue_ar/jupyter/number_field.py
+++ b/glue_ar/jupyter/number_field.py
@@ -1,0 +1,36 @@
+import traitlets
+import ipyvuetify as v
+
+
+# Based on https://github.com/widgetti/ipyvuetify/issues/241
+class NumberField(v.VuetifyTemplate):
+    label = traitlets.Unicode().tag(sync=True)
+    value = traitlets.Unicode().tag(sync=True)
+
+    temp_error = traitlets.Unicode(allow_none=True, default_value=None).tag(sync=True)
+
+    def __init__(self, type, label, error_message, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.number_type = type
+        self.label = label
+        self.error_message = error_message
+
+    @traitlets.default("template")
+    def _template(self):
+        return """
+            <v-text-field
+              :label="label"
+              type="number"
+              v-model="value"
+              @change="temp_rule"
+              :rules="[temp_error]"
+            >
+            </v-text-field>
+        """
+
+    def vue_temp_rule(self, value):
+        self.temp_error = None
+        try:
+            self.number_type(value)
+        except ValueError:
+            self.temp_error = self.error_message

--- a/glue_ar/jupyter/tests/test_dialog.py
+++ b/glue_ar/jupyter/tests/test_dialog.py
@@ -8,10 +8,10 @@ from glue_jupyter import JupyterApplication
 # We can't use the Jupyter vispy widget for these tests until
 # https://github.com/glue-viz/glue-vispy-viewers/pull/388 is released
 from glue_jupyter.ipyvolume.volume import IpyvolumeVolumeView
-from ipyvuetify import Checkbox
+from ipyvuetify import Checkbox, Slider
 
 from glue_ar.common.tests.test_base_dialog import BaseExportDialogTest, DummyState
-from glue_ar.jupyter.export_dialog import JupyterARExportDialog, NumberField
+from glue_ar.jupyter.export_dialog import JupyterARExportDialog
 
 
 class TestJupyterExportDialog(BaseExportDialogTest):
@@ -95,20 +95,16 @@ class TestJupyterExportDialog(BaseExportDialogTest):
         int_widgets = self.dialog.widgets_for_property(state, "cb_int", "Int CB")
         assert len(int_widgets) == 1
         widget = int_widgets[0]
-        assert isinstance(widget, NumberField)
+        assert isinstance(widget, Slider)
         assert widget.label == "Int CB"
-        assert widget.value == "0"
-        assert widget.number_type is int
-        assert widget.error_message == "You must enter a valid integer"
+        assert widget.value == 2
 
         float_widgets = self.dialog.widgets_for_property(state, "cb_float", "Float CB")
         assert len(float_widgets) == 1
         widget = float_widgets[0]
-        assert isinstance(widget, NumberField)
+        assert isinstance(widget, Slider)
         assert widget.label == "Float CB"
-        assert widget.value == "1.7"
-        assert widget.number_type is float
-        assert widget.error_message == "You must enter a valid number"
+        assert widget.value == 0.7
 
         bool_widgets = self.dialog.widgets_for_property(state, "cb_bool", "Bool CB")
         assert len(bool_widgets) == 1

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -57,6 +57,7 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
             widget.setSizePolicy(policy)
 
             value_label = QLabel()
+
             def update_label(value):
                 value_label.setText(f"{value:g}")
 

--- a/glue_ar/qt/tests/test_dialog.py
+++ b/glue_ar/qt/tests/test_dialog.py
@@ -6,8 +6,7 @@ importorskip("glue_qt")
 
 from glue_qt.app import GlueApplication
 from glue_vispy_viewers.volume.qt.volume_viewer import VispyVolumeViewer
-from qtpy.QtGui import QDoubleValidator, QIntValidator
-from qtpy.QtWidgets import QCheckBox, QLabel, QLineEdit
+from qtpy.QtWidgets import QCheckBox, QLabel, QSlider
 
 from glue_ar.common.tests.test_base_dialog import BaseExportDialogTest, DummyState
 from glue_ar.common.scatter_export_options import ARVispyScatterExportOptions
@@ -77,22 +76,24 @@ class TestQtExportDialog(BaseExportDialogTest):
         state = DummyState()
 
         int_widgets = self.dialog._widgets_for_property(state, "cb_int", "Int CB")
-        assert len(int_widgets) == 2
-        label, edit = int_widgets
+        assert len(int_widgets) == 3
+        label, slider, value_label = int_widgets
         assert isinstance(label, QLabel)
         assert label.text() == "Int CB:"
-        assert isinstance(edit, QLineEdit)
-        assert isinstance(edit.validator(), QIntValidator)
-        assert edit.text() == "0"
+        assert isinstance(slider, QSlider)
+        assert slider.value() == 2
+        assert isinstance(value_label, QLabel)
+        assert value_label.text() == "2"
 
         float_widgets = self.dialog._widgets_for_property(state, "cb_float", "Float CB")
-        assert len(float_widgets) == 2
-        label, edit = float_widgets
+        assert len(float_widgets) == 3
+        label, slider, value_label = float_widgets
         assert isinstance(label, QLabel)
         assert label.text() == "Float CB:"
-        assert isinstance(edit, QLineEdit)
-        assert isinstance(edit.validator(), QDoubleValidator)
-        assert edit.text() == "1.7"
+        assert isinstance(slider, QSlider)
+        assert slider.value() == 70
+        assert isinstance(value_label, QLabel)
+        assert value_label.text() == "0.7"
 
         bool_widgets = self.dialog._widgets_for_property(state, "cb_bool", "Bool CB")
         assert len(bool_widgets) == 1
@@ -108,7 +109,7 @@ class TestQtExportDialog(BaseExportDialogTest):
 
         state = ARVispyScatterExportOptions()
         self.dialog._update_layer_ui(state)
-        assert self.dialog.ui.layer_layout.rowCount() == 2
+        assert self.dialog.ui.layer_layout.rowCount() == 1
 
     def test_clear_layout(self):
         self.dialog._clear_layer_layout()

--- a/glue_ar/qt/tests/test_tool_scatter.py
+++ b/glue_ar/qt/tests/test_tool_scatter.py
@@ -95,5 +95,4 @@ class TestScatterExportTool:
                 assert len(value) == 2
                 assert value[0] == "Scatter"
                 assert isinstance(value[1], ARVispyScatterExportOptions)
-                assert value[1].theta_resolution == 10
-                assert value[1].phi_resolution == 10
+                assert value[1].resolution == 10

--- a/glue_ar/qt/tests/test_tool_volume.py
+++ b/glue_ar/qt/tests/test_tool_volume.py
@@ -99,8 +99,7 @@ class TestVolumeExportTool:
             scatter_method, scatter_state = state_dict["Scatter Data"]
             assert scatter_method == "Scatter"
             assert isinstance(scatter_state, ARVispyScatterExportOptions)
-            assert scatter_state.theta_resolution == 10
-            assert scatter_state.phi_resolution == 10
+            assert scatter_state.resolution == 10
 
             volume_method, volume_state = state_dict["Volume Data"]
             assert volume_method == "Isosurface"

--- a/glue_ar/tests/test_utils.py
+++ b/glue_ar/tests/test_utils.py
@@ -162,6 +162,8 @@ def test_clip_sides_native():
         assert clip_sides(viewer_state, clip_size=clip_size) == (max_size, max_size / 2, max_size / 4)
 
 
+@pytest.mark.skipif(not (GLUE_QT_INSTALLED or GLUE_JUPYTER_INSTALLED),
+                    reason="Requires either glue-qt or glue-jupyter to create application")
 def test_mask_for_bounds():
     x_values = range(10, 25)
     y_values = range(130, 145)


### PR DESCRIPTION
This PR makes two primary changes to the export dialogs:
* Use sliders rather than text fields for numerical values. For now we set integer values to have a range of [1, 100], and floats to have a range of [0.01, 1] with a precision of 0.01. This works well for all of the quantities that we currently have (floats are used only for opacities at the moment), but if that's not the case later we can revisit.
* Per a suggestion from Michelle, combine theta and phi resolutions for scatter spheres into just "resolution" at the user dialog level. Internally all of our functions still support making theta and phi resolutions different.