### PR TITLE
Use ranged callback values for sliders

### DIFF
--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -30,7 +30,8 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
 
     data[~isfinite(data)] = isomin - 10
 
-    levels = linspace(isomin, isomax, num=int(options.isosurface_count))
+    isosurface_count = int(options.isosurface_count)
+    levels = linspace(isomin, isomax, num=isosurface_count + 2)
     opacity = 0.25 * layer_state.alpha
     color = layer_color(layer_state)
     color_components = hex_to_components(color)
@@ -38,7 +39,7 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
     sides = clip_sides(viewer_state, clip_size=1)
     sides = tuple(sides[i] for i in (2, 1, 0))
 
-    for level in levels[1:]:
+    for level in levels[1:-1]:
         barr = bytearray()
         level_bin = f"layer_{layer_state.layer.uuid}_level_{level}.bin"
 
@@ -115,14 +116,14 @@ def add_isosurface_layer_usd(
     data[~isfinite(data)] = isomin - 10
 
     isosurface_count = int(options.isosurface_count)
-    levels = linspace(isomin, isomax, isosurface_count)
+    levels = linspace(isomin, isomax, num=isosurface_count + 2)
     opacity = layer_state.alpha
     color = layer_color(layer_state)
     color_components = tuple(hex_to_components(color))
     sides = clip_sides(viewer_state, clip_size=1)
     sides = tuple(sides[i] for i in (2, 1, 0))
 
-    for i, level in enumerate(levels[1:]):
+    for i, level in enumerate(levels[1:-1]):
         alpha = (3 * i + isosurface_count) / (4 * isosurface_count) * opacity
         points, triangles = marching_cubes(data, level)
         if len(points) == 0:
@@ -150,11 +151,11 @@ def add_isosurface_layer_stl(
     data[~isfinite(data)] = isomin - 10
 
     isosurface_count = int(options.isosurface_count)
-    levels = linspace(isomin, isomax, isosurface_count)
+    levels = linspace(isomin, isomax, num=isosurface_count + 2)
     sides = clip_sides(viewer_state, clip_size=1)
     sides = tuple(sides[i] for i in (2, 1, 0))
 
-    for i, level in enumerate(levels[1:]):
+    for level in levels[1:-1]:
         # alpha = (3 * i + isosurface_count) / (4 * isosurface_count) * opacity
         points, triangles = marching_cubes(data, level)
         if len(points) == 0:

--- a/glue_ar/common/ranged_callback.py
+++ b/glue_ar/common/ranged_callback.py
@@ -1,7 +1,10 @@
 from echo.core import CallbackProperty
-from typing import Callable, Optional
+from typing import Optional
 
 from glue_ar.utils import clamp, clamp_with_resolution
+
+
+__all__ = ["RangedCallbackProperty"]
 
 
 class RangedCallbackProperty(CallbackProperty):

--- a/glue_ar/common/ranged_callback.py
+++ b/glue_ar/common/ranged_callback.py
@@ -1,0 +1,27 @@
+from echo.core import CallbackProperty
+from typing import Callable, Optional
+
+from glue_ar.utils import clamp, clamp_with_resolution
+
+
+class RangedCallbackProperty(CallbackProperty):
+
+    def __init__(self,
+                 default: Optional[float] = None,
+                 min_value: float = 0,
+                 max_value: float = 1,
+                 resolution: Optional[float] = None,
+                 **kwargs):
+        super().__init__(default=default, **kwargs)
+        self.min_value = min_value
+        self.max_value = max_value
+        self.resolution = resolution
+
+    def __set__(self, instance, value):
+        if value is not None:
+            if self.resolution is not None:
+                value = clamp_with_resolution(value, self.min_value, self.max_value, self.resolution)
+            else:
+                value = clamp(value, self.min_value, self.max_value)
+
+        super().__set__(instance, value)

--- a/glue_ar/common/scatter_export_options.py
+++ b/glue_ar/common/scatter_export_options.py
@@ -1,12 +1,13 @@
-from echo import CallbackProperty
 from glue.core.state_objects import State
+
+from glue_ar.common.ranged_callback import RangedCallbackProperty
 
 
 __all__ = ["ARVispyScatterExportOptions"]
 
 
 class ARVispyScatterExportOptions(State):
-    resolution = CallbackProperty(10)
+    resolution = RangedCallbackProperty(default=10, min_value=3, max_value=50, resolution=1)
 
 
 class ARIpyvolumeScatterExportOptions(State):

--- a/glue_ar/common/tests/test_ranged_callback.py
+++ b/glue_ar/common/tests/test_ranged_callback.py
@@ -1,0 +1,27 @@
+from glue.core.state_objects import State
+from glue_ar.common.ranged_callback import RangedCallbackProperty
+
+
+class TestState(State):
+    int_value = RangedCallbackProperty(default=10, min_value=5, max_value=25, resolution=1)
+    float_value = RangedCallbackProperty(default=0.7, min_value=0.2, max_value=3.6, resolution=0.02)
+
+
+def test_ranged_callback():
+    state = TestState()
+
+    assert state.int_value == 10
+    state.int_value = -4
+    assert state.int_value == 5
+    state.int_value = 30
+    assert state.int_value == 25
+    state.int_value = 12.7
+    assert state.int_value == 13
+
+    assert state.float_value == 0.7
+    state.float_value = 0
+    assert state.float_value == 0.2
+    state.float_value = 18
+    assert state.float_value == 3.6
+    state.float_value = 0.35
+    assert state.float_value == 0.36

--- a/glue_ar/common/volume_export_options.py
+++ b/glue_ar/common/volume_export_options.py
@@ -1,14 +1,15 @@
-from echo import CallbackProperty
 from glue.core.state_objects import State
+
+from glue_ar.common.ranged_callback import RangedCallbackProperty
 
 
 __all__ = ["ARIsosurfaceExportOptions", "ARVoxelExportOptions"]
 
 
 class ARIsosurfaceExportOptions(State):
-    isosurface_count = CallbackProperty(20)
+    isosurface_count = RangedCallbackProperty(default=20, min_value=1, max_value=50)
 
 
 class ARVoxelExportOptions(State):
-    opacity_cutoff = CallbackProperty(0.1)
-    opacity_resolution = CallbackProperty(0.02)
+    opacity_cutoff = RangedCallbackProperty(default=0.1, min_value=0.01, max_value=1, resolution=0.01)
+    opacity_resolution = RangedCallbackProperty(default=0.02, min_value=0.01, max_value=1, resolution=0.01)

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -96,9 +96,13 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
             link((instance, property), (widget, 'value'))
             return [widget]
         elif t in (int, float):
-            step = 0.01 if t is float else 1
-            min = step
-            max = min * 100
+            instance_type = type(instance)
+            cb_property = getattr(instance_type, property)
+            min = getattr(cb_property, 'min_value', 1 if t is int else 0.01)
+            max = getattr(cb_property, 'max_value', 100 * min)
+            step = getattr(cb_property, 'resolution', None)
+            if step is None:
+                step = 1 if t is int else 0.01
             widget = v.Slider(min=min,
                               max=max,
                               step=step,

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -4,7 +4,7 @@ from ipywidgets import DOMWidget, widget_serialization
 import traitlets
 from typing import Callable, List, Optional
 
-from echo import HasCallbackProperties, add_callback
+from echo import HasCallbackProperties
 from glue.core.state_objects import State
 from glue.viewers.common.viewer import Viewer
 from glue_jupyter.link import link
@@ -105,11 +105,7 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
                               label=display_name,
                               thumb_label=f"{value:g}")
             link((instance, property),
-                 (widget, 'value'))
-
-            def update_label(value):
-                widget.thumb_label = f"{value:g}"
-            add_callback(instance, property, update_label)
+                 (widget, 'v_model'))
 
             return [widget]
         else:

--- a/glue_ar/jupyter/export_dialog.vue
+++ b/glue_ar/jupyter/export_dialog.vue
@@ -1,9 +1,9 @@
 <template>
   <v-dialog
     v-model="dialog_open"
-    width="500px"
+    width="600px"
   >
-    <v-card>
+    <v-card class="pa-3">
       <v-card-title>
         Export 3D File
       </v-card-title>

--- a/glue_ar/jupyter/tests/test_dialog.py
+++ b/glue_ar/jupyter/tests/test_dialog.py
@@ -97,14 +97,14 @@ class TestJupyterExportDialog(BaseExportDialogTest):
         widget = int_widgets[0]
         assert isinstance(widget, Slider)
         assert widget.label == "Int CB"
-        assert widget.value == 2
+        assert widget.v_model == 2
 
         float_widgets = self.dialog.widgets_for_property(state, "cb_float", "Float CB")
         assert len(float_widgets) == 1
         widget = float_widgets[0]
         assert isinstance(widget, Slider)
         assert widget.label == "Float CB"
-        assert widget.value == 0.7
+        assert widget.v_model == 0.7
 
         bool_widgets = self.dialog.widgets_for_property(state, "cb_bool", "Bool CB")
         assert len(bool_widgets) == 1

--- a/glue_ar/qt/tests/test_dialog.py
+++ b/glue_ar/qt/tests/test_dialog.py
@@ -91,9 +91,9 @@ class TestQtExportDialog(BaseExportDialogTest):
         assert isinstance(label, QLabel)
         assert label.text() == "Float CB:"
         assert isinstance(slider, QSlider)
-        assert slider.value() == 70
+        assert slider.value() == 69  # Another value -> index thing (see above comment)
         assert isinstance(value_label, QLabel)
-        assert value_label.text() == "0.7"
+        assert value_label.text() == "0.70"
 
         bool_widgets = self.dialog._widgets_for_property(state, "cb_bool", "Bool CB")
         assert len(bool_widgets) == 1

--- a/glue_ar/qt/tests/test_dialog.py
+++ b/glue_ar/qt/tests/test_dialog.py
@@ -81,7 +81,7 @@ class TestQtExportDialog(BaseExportDialogTest):
         assert isinstance(label, QLabel)
         assert label.text() == "Int CB:"
         assert isinstance(slider, QSlider)
-        assert slider.value() == 2
+        assert slider.value() == 1  # 2 is the second (index 1) step value
         assert isinstance(value_label, QLabel)
         assert value_label.text() == "2"
 

--- a/glue_ar/tests/test_utils.py
+++ b/glue_ar/tests/test_utils.py
@@ -6,7 +6,7 @@ from glue.core import Data
 from glue.viewers.common.viewer import LayerArtist
 from glue_vispy_viewers.volume.volume_viewer import Vispy3DVolumeViewerState
 
-from glue_ar.utils import alpha_composite, binned_opacity, clamp, clamped_opacity, \
+from glue_ar.utils import alpha_composite, binned_opacity, clamp, clamp_with_resolution, clamped_opacity, \
                           clip_linear_transformations, clip_sides, data_count, data_for_layer, \
                           export_label_for_layer, get_resolution, hex_to_components, is_volume_viewer, \
                           iterable_has_nan, iterator_count, layer_color, mask_for_bounds, ndarray_has_nan, \
@@ -344,6 +344,14 @@ def test_clamped_opacity():
     assert clamped_opacity(0.77) == 0.77
     assert clamped_opacity(-2) == 0
     assert clamped_opacity(1.6) == 1
+
+
+def test_clamp_with_resolution():
+    assert clamp_with_resolution(2, 0, 1, 0.5) == 1
+    assert clamp_with_resolution(-1, 0, 1, 0.2) == 0
+    assert clamp_with_resolution(0.5, 0, 1, 0.3) == 0.6
+    assert clamp_with_resolution(16.2, 10, 20, 0.5) == 16
+    assert clamp_with_resolution(5.6, 4.8, 7.2, 1) == 6
 
 
 def test_binned_opacity():

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -356,8 +356,12 @@ def clamped_opacity(opacity: float) -> float:
     return clamp(opacity, 0, 1)
 
 
+def clamp_with_resolution(value: Number, minimum: Number, maximum: Number, resolution: Number) -> Number:
+    return clamp(round(value / resolution) * resolution, minimum, maximum)
+
+
 def binned_opacity(raw_opacity: float, resolution: float) -> float:
-    return clamped_opacity(round(raw_opacity / resolution) * resolution)
+    return clamp_with_resolution(raw_opacity, 0, 1, resolution)
 
 
 def offset_triangles(triangle_indices, offset):


### PR DESCRIPTION
This PR adds a `RangedCallbackProperty` that we can use for values attached to sliders - this is particularly useful for our case as currently we auto-generate pieces of the dialog UIs based on the callback properties attached to states. Additionally, this PR cleans up a few small issues (functional and cosmetic) related to the sliders in the export dialogs.