### PR TITLE
Improvements to glTF scatter export

### DIFF
--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -29,7 +29,7 @@ jobs:
         apt:
           - '^libxcb.*-dev'
           - libxkbcommon-x11-0
-          - libegl1-mesa
+          - libegl1-mesa-dev
           - libhdf5-dev
       envs: |
         - linux: py39-test-all

--- a/glue_ar/__init__.py
+++ b/glue_ar/__init__.py
@@ -11,7 +11,7 @@ def setup_common():
     from .common.usd_builder import USDBuilder  # noqa: F401
     from .common.stl_builder import STLBuilder  # noqa: F401
 
-    from .compression import compress_gltfpack, compress_gltf_pipeline  # noqa: F401
+    from .compression import compress_draco, compress_meshoptimizer  # noqa: F401
 
 
 def setup_qt():

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -12,9 +12,10 @@ from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.scatter_export_options import ARIpyvolumeScatterExportOptions, ARVispyScatterExportOptions
 from glue_ar.common.shapes import cone_triangles, cone_points, cylinder_points, cylinder_triangles, \
                                   normalize, rectangular_prism_triangulation, sphere_triangles
-from glue_ar.gltf_utils import SHORT_MAX, add_points_to_bytearray, add_triangles_to_bytearray, index_mins, index_maxes, SHORT_MAX
-from glue_ar.utils import Viewer3DState, get_stretches, iterable_has_nan, hex_to_components, layer_color, offset_triangles, \
-                          unique_id, xyz_bounds, xyz_for_layer, Bounds
+from glue_ar.gltf_utils import SHORT_MAX, add_points_to_bytearray, add_triangles_to_bytearray, \
+                               index_mins, index_maxes
+from glue_ar.utils import Viewer3DState, get_stretches, iterable_has_nan, hex_to_components, \
+                          layer_color, offset_triangles, unique_id, xyz_bounds, xyz_for_layer, Bounds
 from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.scatter import Scatter3DLayerState, ScatterLayerState3D, \
                                    PointsGetter, box_points_getter, IPYVOLUME_POINTS_GETTERS, \
@@ -248,6 +249,7 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
     if points_per_mesh is None:
         points_per_mesh = n_points
 
+    first_material_index = builder.material_count
     if fixed_color:
         points = []
         tris = []
@@ -327,7 +329,7 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
             count = n_points - start
             if start != 0 and count < points_per_mesh:
                 triangles_count = len(tris)
-                byte_length = count * triangles_len // triangles_count 
+                byte_length = count * triangles_len // triangles_count
                 mesh_triangles = [tri for sphere in tris[:count] for tri in sphere]
                 max_triangle_index = max(idx for tri in mesh_triangles for idx in tri)
                 builder.add_buffer_view(
@@ -373,8 +375,6 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
             size = radius if fixed_size else sizes[i]
             pts = points_getter(point, size)
             points_by_color[cindex].append(pts)
-
-
 
         for cindex, points in points_by_color.items():
 

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -532,7 +532,7 @@ def add_vispy_scatter_layer_gltf(builder: GLTFBuilder,
 
     points_getter = sphere_points_getter(theta_resolution=theta_resolution,
                                          phi_resolution=phi_resolution)
-    points_per_mesh = None
+    points_per_mesh = 1
 
     add_scatter_layer_gltf(builder=builder,
                            viewer_state=viewer_state,
@@ -556,7 +556,7 @@ def add_ipyvolume_scatter_layer_gltf(builder: GLTFBuilder,
     triangle_getter = IPYVOLUME_TRIANGLE_GETTERS.get(geometry, rectangular_prism_triangulation)
     triangles = triangle_getter()
     points_getter = IPYVOLUME_POINTS_GETTERS.get(geometry, box_points_getter)
-    points_per_mesh = None
+    points_per_mesh = 1
 
     add_scatter_layer_gltf(builder=builder,
                            viewer_state=viewer_state,

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -356,7 +356,7 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
             builder.add_accessor(
                 buffer_view=builder.buffer_view_count-1,
                 component_type=ComponentType.UNSIGNED_INT,
-                count=len(mesh_triangles),
+                count=len(mesh_triangles)*3,
                 type=AccessorType.SCALAR,
                 mins=[0],
                 maxes=[max(idx for tri in mesh_triangles for idx in tri)],

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -310,8 +310,11 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
             normalized = max(min((cval - layer_state.cmap_vmin) / crange, 1), 0)
             cindex = int(normalized * 255)
             color = cmap(cindex)
-            builder.add_material(color, layer_state.alpha)
-            color_materials[color] = builder.material_count - 1
+            material_index = color_materials.get(color, None)
+            if material_index is None:
+                builder.add_material(color, layer_state.alpha)
+                material_index = builder.material_count - 1
+                color_materials[color] = material_index
 
             size = radius if fixed_size else sizes[i]
             pts = points_getter(point, size)

--- a/glue_ar/common/tests/gltf_helpers.py
+++ b/glue_ar/common/tests/gltf_helpers.py
@@ -9,7 +9,7 @@ from typing import List, Literal, Optional, Tuple, Union, cast
 from glue_ar.utils import iterator_count
 
 
-BufferFormat = Union[Literal["f"], Literal["I"]]
+BufferFormat = Union[Literal["f"], Literal["I"], Literal["H"]]
 
 
 def get_data(gltf: GLTF, buffer: Buffer, buffer_view: Optional[BufferView] = None) -> bytes:
@@ -41,8 +41,9 @@ def count_vertices(gltf: GLTF, buffer: Buffer, buffer_view: BufferView):
     return count_points(gltf, buffer, buffer_view, 'f')
 
 
-def count_indices(gltf: GLTF, buffer: Buffer, buffer_view: BufferView):
-    return count_points(gltf, buffer, buffer_view, 'I')
+def count_indices(gltf: GLTF, buffer: Buffer, buffer_view: BufferView, use_short=False):
+    format = 'H' if use_short else 'I'
+    return count_points(gltf, buffer, buffer_view, format)
 
 
 def unpack_points(gltf: GLTF,

--- a/glue_ar/common/tests/test_scatter_gltf.py
+++ b/glue_ar/common/tests/test_scatter_gltf.py
@@ -10,6 +10,7 @@ from glue_ar.common.shapes import sphere_points_count, sphere_triangles, sphere_
 from glue_ar.common.tests.gltf_helpers import count_indices, count_vertices, unpack_vertices
 from glue_ar.common.tests.helpers import APP_VIEWER_OPTIONS
 from glue_ar.common.tests.test_scatter import BaseScatterTest
+from glue_ar.gltf_utils import SHORT_MAX
 from glue_ar.utils import export_label_for_layer, hex_to_components, layers_to_export, mask_for_bounds, \
                           xyz_bounds, xyz_for_layer
 
@@ -68,8 +69,8 @@ class TestScatterGLTF(BaseScatterTest):
                                                  phi_resolution=phi_resolution)
         points_count = sphere_points_count(theta_resolution=theta_resolution,
                                            phi_resolution=phi_resolution)
-
-        assert count_indices(gltf, model.buffers[0], model.bufferViews[0]) == triangles_count
+        use_short = points_count <= SHORT_MAX
+        assert count_indices(gltf, model.buffers[0], model.bufferViews[0], use_short=use_short) == triangles_count
         assert count_vertices(gltf, model.buffers[0], model.bufferViews[1]) == points_count
 
         assert model.bufferViews[0].target == BufferTarget.ELEMENT_ARRAY_BUFFER.value
@@ -77,7 +78,8 @@ class TestScatterGLTF(BaseScatterTest):
 
         indices_accessor = model.accessors[0]
         assert indices_accessor.bufferView == 0
-        assert indices_accessor.componentType == ComponentType.UNSIGNED_INT.value
+        expected_indices_type = ComponentType.UNSIGNED_SHORT if use_short else ComponentType.UNSIGNED_INT
+        assert indices_accessor.componentType == expected_indices_type.value
         assert indices_accessor.count == triangles_count * 3
         assert indices_accessor.type == AccessorType.SCALAR.value
         assert indices_accessor.min == [0]

--- a/glue_ar/compression.py
+++ b/glue_ar/compression.py
@@ -6,15 +6,14 @@ from glue_ar.utils import PACKAGE_DIR
 
 
 NODE_MODULES_DIR = join(PACKAGE_DIR, "js", "node_modules")
-GLTF_PIPELINE_FILEPATH = join(NODE_MODULES_DIR, "gltf-pipeline", "bin", "gltf-pipeline.js")
-GLTFPACK_FILEPATH = join(NODE_MODULES_DIR, "gltfpack", "cli.js")
+GLTF_TRANSFORM_FILEPATH = join(NODE_MODULES_DIR, "@gltf-transform", "cli", "bin", "cli.js")
 
 
 @compressor("draco")
-def compress_gltf_pipeline(filepath: str):
-    run(["node", GLTF_PIPELINE_FILEPATH, "-i", filepath, "-o", filepath, "-d"], capture_output=True)
+def compress_draco(filepath: str):
+    run([GLTF_TRANSFORM_FILEPATH, "optimize", filepath, filepath, "--compress", "draco"], capture_output=True)
 
 
 @compressor("meshoptimizer")
-def compress_gltfpack(filepath: str):
-    run(["node", GLTFPACK_FILEPATH, "-i", filepath, "-o", filepath], capture_output=True)
+def compress_meshoptimizer(filepath: str):
+    run([GLTF_TRANSFORM_FILEPATH, "optimize", filepath, filepath], capture_output=True)

--- a/glue_ar/gltf_utils.py
+++ b/glue_ar/gltf_utils.py
@@ -18,6 +18,8 @@ GLTF_COMPRESSION_EXTENSIONS = {
     "meshoptimizer": "EXT_meshopt_compression",
 }
 
+SHORT_MAX = 65_535
+
 
 def create_material_for_color(
     color: List[int],
@@ -40,10 +42,13 @@ def add_points_to_bytearray(arr: bytearray, points: Iterable[Iterable[Union[int,
             arr.extend(struct.pack('f', coordinate))
 
 
-def add_triangles_to_bytearray(arr: bytearray, triangles: Iterable[Iterable[int]]):
+def add_triangles_to_bytearray(arr: bytearray,
+                               triangles: Iterable[Iterable[int]],
+                               short: bool = False):
+    format = "H" if short else "I"
     for triangle in triangles:
         for index in triangle:
-            arr.extend(struct.pack('I', index))
+            arr.extend(struct.pack(format, index))
 
 
 T = TypeVar("T", bound=Union[int, float])

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,6 @@
 {
     "dependencies": {
-        "gltf-pipeline": "^4.1.0",
-        "gltfpack": "^0.21.0"
+        "@gltf-transform/cli": "^4.1.1"
     },
     "scripts": {
         "glue-ar-export": "npm install && node glue-ar-export.js"


### PR DESCRIPTION
This PR makes some improvements to our glTF scatter export. As glTF is probably our most important export format (it's the most widely supported, including what's supported by CoSpaces), it makes sense to try and optimize our glTF export as much as possible. This PR makes a few improvements, some to overall glTF export and some for scatter exports in particular:
* glTF allows exporting indices as `short` values - that is, 2-byte integers rather than 4-byte. If the maximum index in any of the triangles in a given mesh is less than 2^16 = 65,536, we can export the indices with 2 bytes per value and reduce the output filesize. This PR updates our glTF utility method to allow using short integers, and uses this when appropriate in our scatter export.
* There are a few places in our glTF colormapped scatter exports where currently we're making redundant materials. This PR fixes that, which will help with the export filesize.
* This PR updates our compression to use `gltf-transform` rather than `gltf-pipeline` and `gltfpack`. This package includes both Draco and Meshoptimizer compression, as well as some other stuff as well.
* Currently, our glTF scatter exports use one mesh per point. The advantage of this is that since each mesh has the same triangulation, we only need to put in the indices for one mesh and then we can reuse the same buffer view and accessor. This helps to save space, but can be less performant since it requires more draw calls in the client. This PR allows setting a `points_per_mesh` parameter to the layer export method, which allows us to determine whether we want to optimize for filesize or performance. I'm pretty sure that combining meshes together is what some of the optimization extensions do, but it's also nice to offer this for users who need their files to be displayed in a context that doesn't support glTF extensions.
    * Currently there's no option to adjust this in the UI - I'll add this in another PR soon.