### PR TITLE
Fix issues with attempts to remove callback when widget is destroyed

### DIFF
--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -75,9 +75,12 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
                 except ValueError:
                     pass
 
+            def on_widget_destroyed(widget, cb=remove_label_callback):
+                cb(widget)
+
             update_label(value)
             add_callback(instance, property, update_label)
-            widget.destroyed.connect(lambda *args, cb=remove_label_callback: cb(widget))
+            widget.destroyed.connect(on_widget_destroyed)
 
             steps = round((max - min) / step)
             widget.setMinimum(0)

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -69,12 +69,15 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
             def update_label(value):
                 value_label.setText(f"{value:.{places}f}")
 
-            def remove_label_callback(*args):
-                remove_callback(instance, property, update_label)
+            def remove_label_callback(widget, update_label=update_label):
+                try:
+                    remove_callback(instance, property, update_label)
+                except ValueError:
+                    pass
 
             update_label(value)
             add_callback(instance, property, update_label)
-            widget.destroyed.connect(remove_label_callback)
+            widget.destroyed.connect(lambda *args, cb=remove_label_callback: cb(widget))
 
             steps = round((max - min) / step)
             widget.setMinimum(0)

--- a/setup.py
+++ b/setup.py
@@ -754,6 +754,8 @@ extras_require = {
         "ipyfilechooser",
         "ipyvuetify",
         "glue-vispy-viewers[jupyter]",
+        # Temporary - see https://github.com/widgetti/ipyvolume/issues/447
+        "ipython-genutils",
     ],
     "qr": [
         "ngrok",


### PR DESCRIPTION
This PR resolves some issues that we were having when attempting to remove the label-updating callback in some of the exporting dialogs when the label widget was destroyed. These issues were due to a lack of capturing when setting up some of our connections.

Note that it seems that we actually shouldn't need to remove the callback, but we want to try just to make sure that it's gone.
