### PR TITLE
Updates to control mesh configuration

### DIFF
--- a/glue_ar/common/export_dialog_base.py
+++ b/glue_ar/common/export_dialog_base.py
@@ -87,4 +87,6 @@ class ARExportDialogBase:
 
     @staticmethod
     def display_name(prop):
+        if prop == "log_points_per_mesh":
+            return "Points per mesh"
         return prop.replace("_", " ").capitalize()

--- a/glue_ar/common/scatter_export_options.py
+++ b/glue_ar/common/scatter_export_options.py
@@ -20,7 +20,8 @@ class ARVispyScatterExportOptions(State):
             min_value=0,
             max_value=7,
             docstring="Controls how many points are put into each mesh. "
-                       "Higher means a larger filesize, but better performance.")
+                      "Higher means a larger filesize, but better performance."
+    )
 
 
 class ARIpyvolumeScatterExportOptions(State):

--- a/glue_ar/common/scatter_export_options.py
+++ b/glue_ar/common/scatter_export_options.py
@@ -25,4 +25,10 @@ class ARVispyScatterExportOptions(State):
 
 
 class ARIpyvolumeScatterExportOptions(State):
-    pass
+    log_points_per_mesh = RangedCallbackProperty(
+            default=7,
+            min_value=0,
+            max_value=7,
+            docstring="Controls how many points are put into each mesh. "
+                      "Higher means a larger filesize, but better performance."
+    )

--- a/glue_ar/common/scatter_export_options.py
+++ b/glue_ar/common/scatter_export_options.py
@@ -22,5 +22,6 @@ class ARVispyScatterExportOptions(State):
             docstring="Controls how many points are put into each mesh. "
                        "Higher means a larger filesize, but better performance.")
 
+
 class ARIpyvolumeScatterExportOptions(State):
     pass

--- a/glue_ar/common/scatter_export_options.py
+++ b/glue_ar/common/scatter_export_options.py
@@ -15,7 +15,12 @@ class ARVispyScatterExportOptions(State):
             docstring="Controls the resolution of the sphere meshes used for scatter points. "
                       "Higher means better resolution, but a larger filesize.",
     )
-
+    log_points_per_mesh = RangedCallbackProperty(
+            default=7,
+            min_value=0,
+            max_value=7,
+            docstring="Controls how many points are put into each mesh. "
+                       "Higher means a larger filesize, but better performance.")
 
 class ARIpyvolumeScatterExportOptions(State):
     pass

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -211,8 +211,7 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
                            triangles: List[Tuple[int, int, int]],
                            bounds: Bounds,
                            clip_to_bounds: bool = True,
-                           points_per_mesh: Optional[int] = None,
-):
+                           points_per_mesh: Optional[int] = None):
     if layer_state is None:
         return
 
@@ -537,7 +536,7 @@ def add_vispy_scatter_layer_gltf(builder: GLTFBuilder,
     if log_ppm == 7:
         ppm = None
     else:
-       ppm = 10 ** log_ppm 
+        ppm = 10 ** log_ppm
 
     add_scatter_layer_gltf(builder=builder,
                            viewer_state=viewer_state,
@@ -565,7 +564,7 @@ def add_ipyvolume_scatter_layer_gltf(builder: GLTFBuilder,
     if log_ppm == 7:
         ppm = None
     else:
-       ppm = 10 ** log_ppm 
+        ppm = 10 ** log_ppm
 
     add_scatter_layer_gltf(builder=builder,
                            viewer_state=viewer_state,

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -390,6 +390,7 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
                 triangle_offset += pts_count
                 tris.append(pt_triangles)
 
+            triangles_count = len(tris)
             mesh_points = [pt for pts in points for pt in pts]
             mesh_triangles = [tri for sphere in tris for tri in sphere]
             max_triangle_index = max(idx for tri in mesh_triangles for idx in tri)
@@ -448,7 +449,6 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
                 # there's no need to do this - we can use the buffer view that we just created
                 count = n_points - start
                 if start != 0 and count < points_per_mesh:
-                    triangles_count = len(tris)
                     byte_length = count * triangles_len // triangles_count
                     mesh_triangles = [tri for sphere in tris[:count] for tri in sphere]
                     max_triangle_index = max(idx for tri in mesh_triangles for idx in tri)

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -211,7 +211,8 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
                            triangles: List[Tuple[int, int, int]],
                            bounds: Bounds,
                            clip_to_bounds: bool = True,
-                           points_per_mesh: Optional[int] = None):
+                           points_per_mesh: Optional[int] = None,
+):
     if layer_state is None:
         return
 
@@ -532,7 +533,11 @@ def add_vispy_scatter_layer_gltf(builder: GLTFBuilder,
 
     points_getter = sphere_points_getter(theta_resolution=theta_resolution,
                                          phi_resolution=phi_resolution)
-    points_per_mesh = 1
+    log_ppm = int(options.log_points_per_mesh)
+    if log_ppm == 7:
+        ppm = None
+    else:
+       ppm = 10 ** log_ppm 
 
     add_scatter_layer_gltf(builder=builder,
                            viewer_state=viewer_state,
@@ -541,7 +546,7 @@ def add_vispy_scatter_layer_gltf(builder: GLTFBuilder,
                            triangles=triangles,
                            bounds=bounds,
                            clip_to_bounds=clip_to_bounds,
-                           points_per_mesh=points_per_mesh)
+                           points_per_mesh=ppm)
 
 
 @ar_layer_export(Scatter3DLayerState, "Scatter", ARIpyvolumeScatterExportOptions, ("gltf", "glb"))
@@ -556,7 +561,11 @@ def add_ipyvolume_scatter_layer_gltf(builder: GLTFBuilder,
     triangle_getter = IPYVOLUME_TRIANGLE_GETTERS.get(geometry, rectangular_prism_triangulation)
     triangles = triangle_getter()
     points_getter = IPYVOLUME_POINTS_GETTERS.get(geometry, box_points_getter)
-    points_per_mesh = 1
+    log_ppm = int(options.log_points_per_mesh)
+    if log_ppm == 7:
+        ppm = None
+    else:
+       ppm = 10 ** log_ppm 
 
     add_scatter_layer_gltf(builder=builder,
                            viewer_state=viewer_state,
@@ -565,4 +574,4 @@ def add_ipyvolume_scatter_layer_gltf(builder: GLTFBuilder,
                            triangles=triangles,
                            bounds=bounds,
                            clip_to_bounds=clip_to_bounds,
-                           points_per_mesh=points_per_mesh)
+                           points_per_mesh=ppm)

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -186,10 +186,11 @@ class BaseScatterTest:
     def _basic_state_dictionary(self, viewer_type: str) -> Dict[str, Tuple[str, State]]:
         if viewer_type == "vispy":
             def state_maker():
-                return ARVispyScatterExportOptions(theta_resolution=15,
-                                                   phi_resolution=15)
+                return ARVispyScatterExportOptions(resolution=15,
+                                                   log_points_per_mesh=0)
         elif viewer_type == "ipyvolume":
-            state_maker = ARIpyvolumeScatterExportOptions
+            def state_maker():
+                return ARIpyvolumeScatterExportOptions(log_points_per_mesh=0)
         else:
             raise ValueError("Viewer type should be either vispy or ipyvolume")
 

--- a/glue_ar/common/volume_export_options.py
+++ b/glue_ar/common/volume_export_options.py
@@ -32,3 +32,11 @@ class ARVoxelExportOptions(State):
         docstring="The resolution of the opacity in the exported figure. Opacity values will be "
                   "rounded to the nearest integer multiple of this value.",
     )
+
+    log_voxels_per_mesh = RangedCallbackProperty(
+        default=7,
+        min_value=0,
+        max_value=7,
+        docstring="Controls how many voxels are put into each mesh. "
+                  "Higher means a larger filesize, but better performance."
+    )

--- a/glue_ar/common/volume_export_options.py
+++ b/glue_ar/common/volume_export_options.py
@@ -33,10 +33,10 @@ class ARVoxelExportOptions(State):
                   "rounded to the nearest integer multiple of this value.",
     )
 
-    log_voxels_per_mesh = RangedCallbackProperty(
-        default=7,
-        min_value=0,
-        max_value=7,
-        docstring="Controls how many voxels are put into each mesh. "
-                  "Higher means a larger filesize, but better performance."
-    )
+    # log_voxels_per_mesh = RangedCallbackProperty(
+    #     default=7,
+    #     min_value=0,
+    #     max_value=7,
+    #     docstring="Controls how many voxels are put into each mesh. "
+    #               "Higher means a larger filesize, but better performance."
+    # )

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -100,30 +100,20 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
     triangle_offset = 0
     triangles = rectangular_prism_triangulation()
     pts_count = len(rectangular_prism_points((0, 0, 0), tuple(1 for _ in range(3))))
-    print(rectangular_prism_points((0, 0, 0), tuple(1 for _ in range(3))))
-    print(pts_count)
     voxels_per_mesh = min(voxels_per_mesh, max_points_per_opacity)
     for _ in range(voxels_per_mesh):
         voxel_triangles = offset_triangles(triangles, triangle_offset)
-        print(triangle_offset)
-        print(voxel_triangles)
         triangle_offset += pts_count
         tris.append(voxel_triangles)
 
     triangles_count = len(tris)
     mesh_triangles = [tri for box in tris for tri in box]
     max_triangle_index = max(idx for tri in mesh_triangles for idx in tri)
-    print("Initial data")
-    print(f"Max triangle index: {max_triangle_index}")
     use_short = max_triangle_index <= SHORT_MAX
-    print(f"Use short: {use_short}")
 
     triangles_barr = bytearray()
     add_triangles_to_bytearray(triangles_barr, mesh_triangles, short=use_short)
     triangles_len = len(triangles_barr)
-    print([idx for tri in mesh_triangles for idx in tri])
-    print(len([idx for tri in mesh_triangles for idx in tri]))
-    print(f"Triangles bytearray length: {triangles_len}")
 
     builder.add_buffer(byte_length=len(triangles_barr), uri=triangles_bin)
     builder.add_file_resource(triangles_bin, data=triangles_barr)
@@ -191,17 +181,10 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
             # But in this case we do need a separate accessor as the
             # byte length is different.
             count = n_voxels - start
-            print(f"Start: {start}, Count: {count}, VPM: {voxels_per_mesh}")
             if count < voxels_per_mesh:
                 byte_length = count * triangles_len // triangles_count
                 last_mesh_triangles = [tri for box in tris[:count] for tri in box]
                 max_mesh_triangle_index = max(idx for tri in last_mesh_triangles for idx in tri)
-                print(len(last_mesh_triangles))
-                print(max_mesh_triangle_index)
-                print(count)
-                print(byte_length)
-                print(triangles_len, triangles_count)
-                print("======")
                 builder.add_buffer_view(
                     buffer=triangles_buffer,
                     byte_length=byte_length,

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -12,10 +12,10 @@ from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.volume_export_options import ARVoxelExportOptions
 from glue_ar.usd_utils import material_for_color, sanitize_path
 from glue_ar.utils import BoundsWithResolution, alpha_composite, binned_opacity, clamp, \
-                          clip_sides, frb_for_layer, hex_to_components, isomin_for_layer, \
+                          clip_sides, frb_for_layer, get_resolution, hex_to_components, isomin_for_layer, \
                           isomax_for_layer, layer_color, offset_triangles, unique_id, xyz_bounds
 
-from glue_ar.gltf_utils import add_points_to_bytearray, add_triangles_to_bytearray, \
+from glue_ar.gltf_utils import SHORT_MAX, add_points_to_bytearray, add_triangles_to_bytearray, \
                                index_mins, index_maxes
 from glue_ar.common.shapes import rectangular_prism_points, rectangular_prism_triangulation
 
@@ -27,39 +27,16 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
                           viewer_state: Vispy3DVolumeViewerState,
                           layer_states: Iterable[VolumeLayerState],
                           options: Iterable[ARVoxelExportOptions],
-                          bounds: Optional[BoundsWithResolution] = None):
+                          bounds: Optional[BoundsWithResolution] = None,
+                          voxels_per_mesh: Optional[int] = None):
 
     bounds = bounds or xyz_bounds(viewer_state, with_resolution=True)
     sides = clip_sides(viewer_state, clip_size=1)
     sides = tuple(sides[i] for i in (1, 2, 0))
 
-    point_index = 0
-    points_barr = bytearray()
-    triangles_barr = bytearray()
     voxels_id = unique_id()
     points_bin = f"points_{voxels_id}.bin"
     triangles_bin = f"triangles_{voxels_id}.bin"
-
-    triangles = rectangular_prism_triangulation()
-    triangles_barr = bytearray()
-    add_triangles_to_bytearray(triangles_barr, triangles)
-    triangle_barrlen = len(triangles_barr)
-
-    builder.add_buffer_view(
-        buffer=builder.buffer_count+1,
-        byte_length=triangle_barrlen,
-        byte_offset=0,
-        target=BufferTarget.ELEMENT_ARRAY_BUFFER,
-    )
-    builder.add_accessor(
-        buffer_view=builder.buffer_view_count-1,
-        component_type=ComponentType.UNSIGNED_INT,
-        count=len(triangles) * 3,
-        type=AccessorType.SCALAR,
-        mins=[0],
-        maxes=[7],
-    )
-    indices_accessor = builder.accessor_count - 1
 
     opacity_factor = 1
     occupied_voxels = {}
@@ -95,60 +72,163 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
             else:
                 occupied_voxels[indices_tpl] = color_components[:3] + [adjusted_opacity]
 
+    # Once we're done doing the alpha compositing, we want to reverse our dictionary setup
+    # Right now we have (key, value) as (indices, color)
+    # But now we want (color, indices) to do our mesh chunking
     materials_map = {}
+    voxels_by_color = defaultdict(list)
     for indices, rgba in occupied_voxels.items():
-        if rgba[-1] < opacity_cutoff:
-            continue
+        if rgba[-1] >= opacity_cutoff:
+            rgba = tuple(rgba)
+            voxels_by_color[rgba].append(indices)
 
-        center = tuple((-1 + (index + 0.5) * side) for index, side in zip(indices, sides))
+            if rgba in materials_map:
+                material_index = materials_map[rgba]
+            else:
+                material_index = builder.material_count
+                materials_map[rgba] = material_index
+                builder.add_material(
+                    rgba[:3],
+                    rgba[3],
+                )
 
-        pts = rectangular_prism_points(center, sides)
-        prev_ptbarr_len = len(points_barr)
-        point_index += len(pts)
-        add_points_to_bytearray(points_barr, pts)
-        ptbarr_len = len(points_barr)
+    max_points_per_opacity = max(len(voxels) for voxels in voxels_by_color.values())
+    if voxels_per_mesh is None:
+        voxels_per_mesh = max_points_per_opacity
 
-        pt_mins = index_mins(pts)
-        pt_maxes = index_maxes(pts)
+    tris = []
+    triangle_offset = 0
+    triangles = rectangular_prism_triangulation()
+    pts_count = len(rectangular_prism_points((0, 0, 0), tuple(1 for _ in range(3))))
+    print(rectangular_prism_points((0, 0, 0), tuple(1 for _ in range(3))))
+    print(pts_count)
+    voxels_per_mesh = min(voxels_per_mesh, max_points_per_opacity)
+    for _ in range(voxels_per_mesh):
+        voxel_triangles = offset_triangles(triangles, triangle_offset)
+        print(triangle_offset)
+        print(voxel_triangles)
+        triangle_offset += pts_count
+        tris.append(voxel_triangles)
 
-        # We're going to use two buffers
-        # The first one (index 0) for the points
-        # and the second one (index 1) for the triangles
-        builder.add_buffer_view(
-           buffer=builder.buffer_count,
-           byte_length=ptbarr_len-prev_ptbarr_len,
-           byte_offset=prev_ptbarr_len,
-           target=BufferTarget.ARRAY_BUFFER,
-        )
-        builder.add_accessor(
-            buffer_view=builder.buffer_view_count-1,
-            component_type=ComponentType.FLOAT,
-            count=len(pts),
-            type=AccessorType.VEC3,
-            mins=pt_mins,
-            maxes=pt_maxes,
-        )
-        rgba_tpl = tuple(rgba)
-        if rgba_tpl in materials_map:
-            material_index = materials_map[rgba_tpl]
-        else:
-            material_index = builder.material_count
-            materials_map[rgba_tpl] = material_index
-            builder.add_material(
-                rgba[:3],
-                rgba[3],
+    triangles_count = len(tris)
+    mesh_triangles = [tri for box in tris for tri in box]
+    max_triangle_index = max(idx for tri in mesh_triangles for idx in tri)
+    print("Initial data")
+    print(f"Max triangle index: {max_triangle_index}")
+    use_short = max_triangle_index <= SHORT_MAX
+    print(f"Use short: {use_short}")
+
+    triangles_barr = bytearray()
+    add_triangles_to_bytearray(triangles_barr, mesh_triangles, short=use_short)
+    triangles_len = len(triangles_barr)
+    print([idx for tri in mesh_triangles for idx in tri])
+    print(len([idx for tri in mesh_triangles for idx in tri]))
+    print(f"Triangles bytearray length: {triangles_len}")
+
+    builder.add_buffer(byte_length=len(triangles_barr), uri=triangles_bin)
+    builder.add_file_resource(triangles_bin, data=triangles_barr)
+
+    triangles_buffer = builder.buffer_count - 1
+    points_buffer = builder.buffer_count
+    builder.add_buffer_view(
+        buffer=triangles_buffer,
+        byte_length=triangles_len,
+        byte_offset=0,
+        target=BufferTarget.ELEMENT_ARRAY_BUFFER,
+    )
+
+    component_type = ComponentType.UNSIGNED_SHORT if use_short else ComponentType.UNSIGNED_INT
+    builder.add_accessor(
+        buffer_view=builder.buffer_view_count-1,
+        component_type=component_type,
+        count=len(mesh_triangles)*3,
+        type=AccessorType.SCALAR,
+        mins=[0],
+        maxes=[max_triangle_index],
+    )
+
+    points_barr = bytearray()
+    default_triangles_accessor = builder.accessor_count - 1
+    for rgba, voxels in voxels_by_color.items():
+
+        triangles_accessor = default_triangles_accessor
+        start = 0
+        n_voxels = len(voxels)
+        while start < n_voxels:
+            mesh_indices = voxels[start:start+voxels_per_mesh]
+            points = []
+            for indices in mesh_indices:
+                center = tuple((-1 + (index + 0.5) * side) for index, side in zip(indices, sides))
+                pts = rectangular_prism_points(center, sides)
+                points.append(pts)
+
+            prev_ptbarr_len = len(points_barr)
+            mesh_points = [c for pt in points for c in pt]
+            add_points_to_bytearray(points_barr, mesh_points)
+            ptbarr_len = len(points_barr)
+
+            pt_mins = index_mins(mesh_points)
+            pt_maxes = index_maxes(mesh_points)
+
+            builder.add_buffer_view(
+               buffer=points_buffer,
+               byte_length=ptbarr_len-prev_ptbarr_len,
+               byte_offset=prev_ptbarr_len,
+               target=BufferTarget.ARRAY_BUFFER,
             )
-        builder.add_mesh(
-            position_accessor=builder.accessor_count-1,
-            indices_accessor=indices_accessor,
-            material=material_index
-        )
+            builder.add_accessor(
+                buffer_view=builder.buffer_view_count-1,
+                component_type=ComponentType.FLOAT,
+                count=len(mesh_points),
+                type=AccessorType.VEC3,
+                mins=pt_mins,
+                maxes=pt_maxes,
+            )
+            points_accessor = builder.accessor_count - 1
+
+            # This should only happen on the final iteration
+            # or not at all, if voxels_per_mesh is a divisor of count
+            # But in this case we do need a separate accessor as the
+            # byte length is different.
+            count = n_voxels - start
+            print(f"Start: {start}, Count: {count}, VPM: {voxels_per_mesh}")
+            if count < voxels_per_mesh:
+                byte_length = count * triangles_len // triangles_count
+                last_mesh_triangles = [tri for box in tris[:count] for tri in box]
+                max_mesh_triangle_index = max(idx for tri in last_mesh_triangles for idx in tri)
+                print(len(last_mesh_triangles))
+                print(max_mesh_triangle_index)
+                print(count)
+                print(byte_length)
+                print(triangles_len, triangles_count)
+                print("======")
+                builder.add_buffer_view(
+                    buffer=triangles_buffer,
+                    byte_length=byte_length,
+                    byte_offset=0,
+                    target=BufferTarget.ELEMENT_ARRAY_BUFFER,
+                )
+
+                component_type = ComponentType.UNSIGNED_SHORT if use_short else ComponentType.UNSIGNED_INT
+                builder.add_accessor(
+                    buffer_view=builder.buffer_view_count-1,
+                    component_type=component_type,
+                    count=len(last_mesh_triangles)*3,
+                    type=AccessorType.SCALAR,
+                    mins=[0],
+                    maxes=[max_mesh_triangle_index]
+                )
+                triangles_accessor = builder.accessor_count - 1
+
+            builder.add_mesh(
+                position_accessor=points_accessor,
+                indices_accessor=triangles_accessor,
+                material=materials_map[rgba],
+            )
+            start += voxels_per_mesh
 
     builder.add_buffer(byte_length=len(points_barr), uri=points_bin)
-    builder.add_buffer(byte_length=len(triangles_barr), uri=triangles_bin)
-
     builder.add_file_resource(points_bin, data=points_barr)
-    builder.add_file_resource(triangles_bin, data=triangles_barr)
 
 
 @ar_layer_export(VolumeLayerState, "Voxel", ARVoxelExportOptions, ("usda", "usdc", "usdz"), multiple=True)

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -12,7 +12,7 @@ from glue_ar.common.usd_builder import USDBuilder
 from glue_ar.common.volume_export_options import ARVoxelExportOptions
 from glue_ar.usd_utils import material_for_color, sanitize_path
 from glue_ar.utils import BoundsWithResolution, alpha_composite, binned_opacity, clamp, \
-                          clip_sides, frb_for_layer, get_resolution, hex_to_components, isomin_for_layer, \
+                          clip_sides, frb_for_layer, hex_to_components, isomin_for_layer, \
                           isomax_for_layer, layer_color, offset_triangles, unique_id, xyz_bounds
 
 from glue_ar.gltf_utils import SHORT_MAX, add_points_to_bytearray, add_triangles_to_bytearray, \

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -70,8 +70,12 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         input_widgets = []
         self.layer_layout = v.Col()
         for property, _ in state.iter_callback_properties():
+            is_log_ppm = (property == "log_points_per_mesh")
+            # TODO: Think of a cleaner way to handle this
+            if is_log_ppm and self.state.filetype.lower() not in ("gltf", "glb"):
+                continue
             name = self.display_name(property)
-            widgets = widgets_for_callback_property(state, property, name)
+            widgets = widgets_for_callback_property(state, property, name, label_for_value=not is_log_ppm)
             input_widgets.extend(w for w in widgets if isinstance(w, v.Slider))
             rows.append(v.Row(children=widgets, align="center"))
 
@@ -86,6 +90,8 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
 
     def _on_filetype_change(self, filetype: str):
         super()._on_filetype_change(filetype)
+        state = self._layer_export_states[self.state.layer][self.state.method]
+        self._update_layer_ui(state)
         gl = filetype.lower() in ("gltf", "glb")
         self.show_compression = gl
         self.show_modelviewer = gl

--- a/glue_ar/jupyter/export_dialog.py
+++ b/glue_ar/jupyter/export_dialog.py
@@ -70,12 +70,12 @@ class JupyterARExportDialog(ARExportDialogBase, VuetifyTemplate):
         input_widgets = []
         self.layer_layout = v.Col()
         for property, _ in state.iter_callback_properties():
-            is_log_ppm = (property == "log_points_per_mesh")
+            is_log_pm = (property in ("log_points_per_mesh", "log_voxels_per_mesh"))
             # TODO: Think of a cleaner way to handle this
-            if is_log_ppm and self.state.filetype.lower() not in ("gltf", "glb"):
+            if is_log_pm and self.state.filetype.lower() not in ("gltf", "glb"):
                 continue
             name = self.display_name(property)
-            widgets = widgets_for_callback_property(state, property, name, label_for_value=not is_log_ppm)
+            widgets = widgets_for_callback_property(state, property, name, label_for_value=not is_log_pm)
             input_widgets.extend(w for w in widgets if isinstance(w, v.Slider))
             rows.append(v.Row(children=widgets, align="center"))
 

--- a/glue_ar/jupyter/tests/test_dialog.py
+++ b/glue_ar/jupyter/tests/test_dialog.py
@@ -99,7 +99,7 @@ class TestJupyterExportDialog(BaseExportDialogTest):
         state.layer = "Scatter Data"
         assert self.dialog.method_selected == 0
         assert self.dialog.method_items == [{"text": "Scatter", "value": 0}]
-        assert not self.dialog.has_layer_options
+        assert self.dialog.has_layer_options
 
         state.layer = "Volume Data"
         assert self.dialog.method_items[self.dialog.method_selected]["text"] == state.method
@@ -109,7 +109,7 @@ class TestJupyterExportDialog(BaseExportDialogTest):
         state.layer = "Scatter Data"
         assert self.dialog.method_selected == 0
         assert self.dialog.method_items == [{"text": "Scatter", "value": 0}]
-        assert not self.dialog.has_layer_options
+        assert self.dialog.has_layer_options
 
     def test_on_cancel(self):
         self.dialog.vue_cancel_dialog()

--- a/glue_ar/jupyter/widgets.py
+++ b/glue_ar/jupyter/widgets.py
@@ -39,7 +39,9 @@ def info_icon(cb_property: CallbackProperty) -> v.Tooltip:
 
 def boolean_callback_widgets(instance: HasCallbackProperties,
                              property: str,
-                             display_name: str) -> Tuple[DOMWidget]:
+                             display_name: str,
+                             **kwargs,
+) -> Tuple[DOMWidget]:
 
     instance_type = type(instance)
     cb_property = getattr(instance_type, property)
@@ -56,7 +58,10 @@ def boolean_callback_widgets(instance: HasCallbackProperties,
 
 def number_callback_widgets(instance: HasCallbackProperties,
                             property: str,
-                            display_name: str) -> Tuple[DOMWidget]:
+                            display_name: str,
+                            label_for_value=False,
+                            **kwargs,
+) -> Tuple[DOMWidget]:
 
     value = getattr(instance, property)
     instance_type = type(instance)
@@ -68,14 +73,15 @@ def number_callback_widgets(instance: HasCallbackProperties,
     step = getattr(cb_property, 'resolution', None)
     if step is None:
         step = 1 if t is int else 0.01
+
     slider = v.Slider(
             min=min,
             max=max,
             step=step,
             label=display_name,
             hide_details=True,
-            thumb_label=f"{value:g}",
-        )
+            thumb_label=f"{value:g}" if label_for_value else False,
+    )
     link((instance, property),
          (slider, 'v_model'))
 
@@ -89,7 +95,9 @@ def number_callback_widgets(instance: HasCallbackProperties,
 def widgets_for_callback_property(
         instance: HasCallbackProperties,
         property: str,
-        display_name: str) -> Tuple[DOMWidget]:
+        display_name: str,
+        **kwargs,
+) -> Tuple[DOMWidget]:
 
     t = type(getattr(instance, property))
     if t is bool:

--- a/glue_ar/jupyter/widgets.py
+++ b/glue_ar/jupyter/widgets.py
@@ -40,8 +40,7 @@ def info_icon(cb_property: CallbackProperty) -> v.Tooltip:
 def boolean_callback_widgets(instance: HasCallbackProperties,
                              property: str,
                              display_name: str,
-                             **kwargs,
-) -> Tuple[DOMWidget]:
+                             **kwargs) -> Tuple[DOMWidget]:
 
     instance_type = type(instance)
     cb_property = getattr(instance_type, property)
@@ -60,8 +59,7 @@ def number_callback_widgets(instance: HasCallbackProperties,
                             property: str,
                             display_name: str,
                             label_for_value=False,
-                            **kwargs,
-) -> Tuple[DOMWidget]:
+                            **kwargs) -> Tuple[DOMWidget]:
 
     value = getattr(instance, property)
     instance_type = type(instance)

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -63,9 +63,13 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
     def _update_layer_ui(self, state: State):
         self._clear_layer_layout()
         for property in state.callback_properties():
+            is_log_ppm = (property == "log_points_per_mesh")
+            # TODO: Think of a cleaner way to handle this
+            if is_log_ppm and self.state.filetype.lower() not in ("gltf", "glb"):
+                continue
             row = QVBoxLayout()
             name = self.display_name(property)
-            widget_tuples, connection = widgets_for_callback_property(state, property, name)
+            widget_tuples, connection = widgets_for_callback_property(state, property, name, label_for_value=not is_log_ppm)
             self._layer_connections.append(connection)
             for widgets in widget_tuples:
                 subrow = QHBoxLayout()
@@ -79,6 +83,8 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
 
     def _on_filetype_change(self, filetype: str):
         super()._on_filetype_change(filetype)
+        state = self._layer_export_states[self.state.layer][self.state.method]
+        self._update_layer_ui(state)
         gl = filetype.lower() in ("gltf", "glb")
         self.ui.combosel_compression.setVisible(gl)
         self.ui.label_compression_message.setVisible(gl)

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -69,7 +69,8 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
                 continue
             row = QVBoxLayout()
             name = self.display_name(property)
-            widget_tuples, connection = widgets_for_callback_property(state, property, name, label_for_value=not is_log_pm)
+            widget_tuples, connection = widgets_for_callback_property(state, property, name,
+                                                                      label_for_value=not is_log_pm)
             self._layer_connections.append(connection)
             for widgets in widget_tuples:
                 subrow = QHBoxLayout()

--- a/glue_ar/qt/export_dialog.py
+++ b/glue_ar/qt/export_dialog.py
@@ -63,13 +63,13 @@ class QtARExportDialog(ARExportDialogBase, QDialog):
     def _update_layer_ui(self, state: State):
         self._clear_layer_layout()
         for property in state.callback_properties():
-            is_log_ppm = (property == "log_points_per_mesh")
+            is_log_pm = (property in ("log_points_per_mesh", "log_voxels_per_mesh"))
             # TODO: Think of a cleaner way to handle this
-            if is_log_ppm and self.state.filetype.lower() not in ("gltf", "glb"):
+            if is_log_pm and self.state.filetype.lower() not in ("gltf", "glb"):
                 continue
             row = QVBoxLayout()
             name = self.display_name(property)
-            widget_tuples, connection = widgets_for_callback_property(state, property, name, label_for_value=not is_log_ppm)
+            widget_tuples, connection = widgets_for_callback_property(state, property, name, label_for_value=not is_log_pm)
             self._layer_connections.append(connection)
             for widgets in widget_tuples:
                 subrow = QHBoxLayout()

--- a/glue_ar/qt/tests/test_dialog.py
+++ b/glue_ar/qt/tests/test_dialog.py
@@ -78,7 +78,7 @@ class TestQtExportDialog(BaseExportDialogTest):
 
         state = ARVispyScatterExportOptions()
         self.dialog._update_layer_ui(state)
-        assert self.dialog.ui.layer_layout.count() == 1
+        assert self.dialog.ui.layer_layout.count() == 2
 
     def test_clear_layout(self):
         self.dialog._clear_layer_layout()

--- a/glue_ar/qt/widgets.py
+++ b/glue_ar/qt/widgets.py
@@ -48,8 +48,7 @@ def info_button(cb_property: CallbackProperty) -> QPushButton:
 def boolean_callback_widgets(instance: HasCallbackProperties,
                              property: str,
                              display_name: str,
-                             **kwargs,
-) -> Tuple[Tuple[Tuple[QWidget]], connect_checkable_button]:
+                             **kwargs) -> Tuple[Tuple[Tuple[QWidget]], connect_checkable_button]:
 
     value = getattr(instance, property)
     instance_type = type(instance)
@@ -71,8 +70,7 @@ def number_callback_widgets(instance: HasCallbackProperties,
                             property: str,
                             display_name: str,
                             label_for_value=True,
-                            **kwargs,
-) -> Tuple[Tuple[Tuple[QWidget]], connect_value]:
+                            **kwargs) -> Tuple[Tuple[Tuple[QWidget]], connect_value]:
 
     value = getattr(instance, property)
     instance_type = type(instance)
@@ -99,6 +97,7 @@ def number_callback_widgets(instance: HasCallbackProperties,
 
     if label_for_value:
         value_label = QLabel()
+
         def update_label(value):
             value_label.setText(f"{value:.{places}f}")
 
@@ -114,7 +113,7 @@ def number_callback_widgets(instance: HasCallbackProperties,
         update_label(value)
         add_callback(instance, property, update_label)
         slider.destroyed.connect(on_widget_destroyed)
-        
+
         value_widgets = (slider, value_label)
     else:
         value_widgets = (slider,)
@@ -135,8 +134,7 @@ def number_callback_widgets(instance: HasCallbackProperties,
 def widgets_for_callback_property(instance: HasCallbackProperties,
                                   property: str,
                                   display_name: str,
-                                  **kwargs,
-) -> Tuple[Tuple[Tuple[QWidget]], BaseConnection]:
+                                  **kwargs) -> Tuple[Tuple[Tuple[QWidget]], BaseConnection]:
 
     t = type(getattr(instance, property))
     if t is bool:

--- a/glue_ar/qt/widgets.py
+++ b/glue_ar/qt/widgets.py
@@ -47,7 +47,9 @@ def info_button(cb_property: CallbackProperty) -> QPushButton:
 
 def boolean_callback_widgets(instance: HasCallbackProperties,
                              property: str,
-                             display_name: str) -> Tuple[Tuple[Tuple[QWidget]], connect_checkable_button]:
+                             display_name: str,
+                             **kwargs,
+) -> Tuple[Tuple[Tuple[QWidget]], connect_checkable_button]:
 
     value = getattr(instance, property)
     instance_type = type(instance)
@@ -67,7 +69,10 @@ def boolean_callback_widgets(instance: HasCallbackProperties,
 
 def number_callback_widgets(instance: HasCallbackProperties,
                             property: str,
-                            display_name: str) -> Tuple[Tuple[Tuple[QWidget]], connect_value]:
+                            display_name: str,
+                            label_for_value=True,
+                            **kwargs,
+) -> Tuple[Tuple[Tuple[QWidget]], connect_value]:
 
     value = getattr(instance, property)
     instance_type = type(instance)
@@ -85,7 +90,6 @@ def number_callback_widgets(instance: HasCallbackProperties,
     slider.setOrientation(Qt.Orientation.Horizontal)
     slider.setSizePolicy(policy)
 
-    value_label = QLabel()
     min = getattr(cb_property, 'min_value', 1 if t is int else 0.01)
     max = getattr(cb_property, 'max_value', 100 * min)
     step = getattr(cb_property, 'resolution', None)
@@ -93,28 +97,33 @@ def number_callback_widgets(instance: HasCallbackProperties,
         step = 1 if t is int else 0.01
     places = -floor(log(step, 10))
 
-    def update_label(value):
-        value_label.setText(f"{value:.{places}f}")
+    if label_for_value:
+        value_label = QLabel()
+        def update_label(value):
+            value_label.setText(f"{value:.{places}f}")
 
-    def remove_label_callback(widget, update_label=update_label):
-        try:
-            remove_callback(instance, property, update_label)
-        except ValueError:
-            pass
+        def remove_label_callback(widget, update_label=update_label):
+            try:
+                remove_callback(instance, property, update_label)
+            except ValueError:
+                pass
 
-    def on_widget_destroyed(widget, cb=remove_label_callback):
-        cb(widget)
+        def on_widget_destroyed(widget, cb=remove_label_callback):
+            cb(widget)
 
-    update_label(value)
-    add_callback(instance, property, update_label)
-    slider.destroyed.connect(on_widget_destroyed)
+        update_label(value)
+        add_callback(instance, property, update_label)
+        slider.destroyed.connect(on_widget_destroyed)
+        
+        value_widgets = (slider, value_label)
+    else:
+        value_widgets = (slider,)
 
     steps = round((max - min) / step)
     slider.setMinimum(0)
     slider.setMaximum(steps)
     connection = connect_value(instance, property, slider, value_range=(min, max))
 
-    value_widgets = (slider, value_label)
     if cb_property.__doc__:
         button = info_button(cb_property)
         spacer = horizontal_spacer(width=40, height=20)
@@ -125,12 +134,14 @@ def number_callback_widgets(instance: HasCallbackProperties,
 
 def widgets_for_callback_property(instance: HasCallbackProperties,
                                   property: str,
-                                  display_name: str) -> Tuple[Tuple[Tuple[QWidget]], BaseConnection]:
+                                  display_name: str,
+                                  **kwargs,
+) -> Tuple[Tuple[Tuple[QWidget]], BaseConnection]:
 
     t = type(getattr(instance, property))
     if t is bool:
-        return boolean_callback_widgets(instance, property, display_name)
+        return boolean_callback_widgets(instance, property, display_name, **kwargs)
     elif t in (int, float):
-        return number_callback_widgets(instance, property, display_name)
+        return number_callback_widgets(instance, property, display_name, **kwargs)
     else:
         raise ValueError("Unsupported callback property type!")


### PR DESCRIPTION
This PR makes a few changes regarding the mesh structure of our scatter and glTF exports. The list of changes here is:
* Allow setting the maximum number of points (spheres) per mesh in glTF scatter exports. If the number of spheres for a given material is lower than the maximum value, all of the spheres for that material are put into one mesh. While we don't show this to the user, the points per mesh values are 1, 10, 100, 1000, 10000, 100000, 1000000, and "all points."
* Implement this mesh chunking for voxel exports as well. In my testing, exports using more voxels per mesh are often smaller, in addition to being more performant. Thus, I didn't add an option for the user to adjust this. I suspect that this is because there are generally so many voxels that removing the buffer views and accessors actually saves more space than it costs to add the additional triangle indices to the buffer.

Overall, the effect of this is to somewhat replicate the effects of Meshopt compression. While it makes sense for a user to use compression when they can, this is helpful for cases where the user wants to load the exported file into a client that doesn't support compression extensions.