### PR TITLE
Add output file extension if one is missing

### DIFF
--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -41,7 +41,8 @@ class JupyterARExportTool(Tool):
             display(self.export_dialog)
 
     def _open_file_dialog(self):
-        file_chooser = FileChooser(getcwd(), filter_pattern=f"*.{self.export_dialog.state.filetype}")
+        filetype = self.export_dialog.state.filetype.lower()
+        file_chooser = FileChooser(getcwd(), filter_pattern=f"*.{filetype}")
         ok_btn = v.Btn(color='success', disabled=True, children=['Ok'])
         close_btn = v.Btn(color='error', children=['Close'])
         dialog = v.Dialog(

--- a/glue_ar/jupyter/export_tool.py
+++ b/glue_ar/jupyter/export_tool.py
@@ -77,6 +77,11 @@ class JupyterARExportTool(Tool):
             display(dialog)
 
     def maybe_save_figure(self, filepath):
+
+        if "." not in filepath:
+            filetype = self.export_dialog.state.filetype.lower()
+            filepath += f".{filetype}"
+
         if exists(filepath):
             yes_btn = v.Btn(color='success', children=["Yes"])
             no_btn = v.Btn(color='error', children=["No"])

--- a/glue_ar/qt/export_tool.py
+++ b/glue_ar/qt/export_tool.py
@@ -48,10 +48,20 @@ class QtARExportTool(Tool):
         if result == QDialog.Rejected:
             return
 
+        filetype = dialog.state.filetype
+        extension = dialog.state.filetype.lower()
+        filter = f"{filetype} file (*.{extension})"
+
         export_path, _ = compat.getsavefilename(parent=self.viewer,
-                                                basedir=f"{self._default_filename}.{dialog.state.filetype.lower()}")
+                                                basedir=f"{self._default_filename}.{extension}",
+                                                filters=filter,
+                                                selectedfilter=filter)
+
         if not export_path:
             return
+
+        if "." not in export_path:
+            export_path += f".{extension}"
 
         layer_states = [layer.state for layer in self.viewer.layers if
                         layer.enabled and layer.state.visible]


### PR DESCRIPTION
This PR is to address an issue that I've noticed on MacOS: if one selects an existing file using the system file selection window (which Qt uses), the extension isn't included. The solution used here is taken from [what `glue-qt` does](https://github.com/glue-viz/glue-qt/blob/main/glue_qt/app/application.py#L1049); clearly the same issue popped up there with saving sessions. I haven't noticed this on other operating systems.