### PR TITLE
Update examples to use dark backgrounds

### DIFF
--- a/docs/examples/edenhofer-voxel-350.html
+++ b/docs/examples/edenhofer-voxel-350.html
@@ -8,7 +8,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {

--- a/docs/examples/gum-nebula-both-isosurface.html
+++ b/docs/examples/gum-nebula-both-isosurface.html
@@ -7,7 +7,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {

--- a/docs/examples/homology_voids_isosurface_draco.html
+++ b/docs/examples/homology_voids_isosurface_draco.html
@@ -7,7 +7,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {

--- a/docs/examples/leike_voxel.html
+++ b/docs/examples/leike_voxel.html
@@ -7,7 +7,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {

--- a/docs/examples/local_bubble_b_field.html
+++ b/docs/examples/local_bubble_b_field.html
@@ -7,7 +7,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {

--- a/docs/examples/m83_voxel_stretch.html
+++ b/docs/examples/m83_voxel_stretch.html
@@ -7,7 +7,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {

--- a/docs/examples/ngc3132_isosurface.html
+++ b/docs/examples/ngc3132_isosurface.html
@@ -7,7 +7,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {

--- a/docs/examples/protodisk.html
+++ b/docs/examples/protodisk.html
@@ -7,7 +7,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {

--- a/docs/examples/radwave.html
+++ b/docs/examples/radwave.html
@@ -3,6 +3,11 @@
         <body>
             <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/3.3.0/model-viewer.min.js"></script>
             <style>
+        body {
+          margin: 0;
+          background-color: black;
+        }
+
         model-viewer {
           width: 100%;
           height: 100%;

--- a/docs/examples/radwave_first.html
+++ b/docs/examples/radwave_first.html
@@ -8,7 +8,7 @@
 
 body {
   margin: 0;
-  background-color: white;
+  background-color: black;
 }
 
 model-viewer {


### PR DESCRIPTION
This is a simple PR to update some of our model-viewer examples (in particular, the ones that we might use at AAS) to have black backgrounds.