### PR TITLE
Allow setting QR code error correction level

### DIFF
--- a/glue_ar/common/qr.py
+++ b/glue_ar/common/qr.py
@@ -23,10 +23,10 @@ def get_local_ip():
     return IP
 
 
-def create_qr(url, with_logo=True, color=GLUE_RED):
-    qr = segno.make_qr(url)
+def create_qr(url, with_logo=True, color=GLUE_RED, error_level="H"):
+    qr = segno.make_qr(url, error=error_level)
     out = BytesIO()
-    qr.save(out, kind="png", scale=7, dark=color, light="white")
+    qr.save(out, kind="png", scale=10, dark=color, light="white")
     out.seek(0)
     img = Image.open(out)
     img = img.convert("RGB")
@@ -35,7 +35,7 @@ def create_qr(url, with_logo=True, color=GLUE_RED):
         logo_max_size = height // 3
         logo_img = Image.open(GLUE_LOGO)
         # Resize the logo to logo_max_size
-        logo_img.thumbnail((logo_max_size, logo_max_size), Image.Resampling.LANCZOS)
+        logo_img.thumbnail((logo_max_size, logo_max_size), resample=Image.Resampling.LANCZOS)
         # Calculate the center of the QR code
         box = ((width - logo_img.size[0]) // 2, (height - logo_img.size[1]) // 2)
         img.paste(logo_img, box)


### PR DESCRIPTION
This PR makes two changes to the QR code creation code related to the error correction level:
* Allow setting the error correction level of the created QR code
* Use level H by default, as this is recommended for codes with embedded images (which we're often doing with the glue logo)
