### PR TITLE
Add descriptions of example formats

### DIFF
--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -3213,7 +3213,7 @@
 }
 
 #examples {
-  margin: 0 0 2em 0;
+  margin-bottom: 2em;
 }
 
 /* Grid borders adapted from https://geary.co/internal-borders-css-grid/ */

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,12 @@
 
     <section id="examples" class="nav-item container">
       <h2>Examples</h2>
-      <p>Below are some examples of files generated using glue-ar. Scan the QR codes to see the figures in AR on your phone!</p>
+      <p>Below are some examples of files generated using glue-ar. Scan the QR codes to see the figures in AR on your phone! We provide three types of interactives for most of our examples:</p>
+      <ul>
+        <li><strong><em>model-viewer</em></strong>: These use Google's <a href="https://modelviewer.dev/">model-viewer</a> web component to allow you to view figures in tabletop AR directly from your phone. No app required!</li>
+        <li><strong><em>CoSpaces - tabletop</em></strong>: These allow viewing the model in AR using <a href="https://www.cospaces.io/">CoSpaces</a> in a tabletop format. This method requires installing the CoSpaces app.</li>
+        <li><strong><em>CoSpaces - MERGE</em></strong>: These also use CoSpaces, but allow holding the model in your hand via the <a href="https://mergeedu.com/cube">MERGE Cube</a>. To use these, you can either buy a MERGE Cube, or create your own <a href="https://support.mergeedu.com/hc/en-us/articles/360052933492-Making-a-Merge-Paper-Cube">paper MERGE Cube</a>. This method requires installing the CoSpaces app.</li>
+      </ul>
       <!-- 
         If you need to change these QR codes in the future, they were generated using glue-ar's QR code utility
         `glue_ar.common.qr.create_qr`


### PR DESCRIPTION
This PR makes a few updates to the docs page:
* Fix the centering of the example section
* Add descriptions of our example interactive types
* Add link to paper MERGE Cube so that people know how to make their own