### PR TITLE
Create USD stage in memory

### DIFF
--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -30,9 +30,7 @@ def export_viewer(viewer_state: Vispy3DViewerState,
     base, ext = splitext(filepath)
     ext = ext[1:]
     builder_cls = builder_registry.members.get(ext)
-    count = len(getfullargspec(builder_cls.__init__)[0])
-    builder_args = [filepath] if count > 1 else []
-    builder = builder_cls(*builder_args)
+    builder = builder_cls()
     layer_groups = defaultdict(list)
     export_groups = defaultdict(list)
     for layer_state in layer_states:

--- a/glue_ar/common/export.py
+++ b/glue_ar/common/export.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from inspect import getfullargspec
 from os.path import extsep, join, split, splitext
 from string import Template
 from typing import Dict, Optional

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -178,9 +178,9 @@ class BaseScatterTest:
         if hasattr(self, 'viewer'):
             if hasattr(self.viewer, "close"):
                 spec = getfullargspec(self.viewer.close)
-                kwargs = spec[4]
+                args = spec[0]
                 try:
-                    if "warn" in kwargs:
+                    if "warn" in args:
                         self.viewer.close(warn=False)
                     else:
                         self.viewer.close()

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -1,3 +1,4 @@
+from inspect import getfullargspec
 from itertools import product
 from math import sqrt
 from numpy import array, array_equal, nan, ones
@@ -176,7 +177,12 @@ class BaseScatterTest:
             remove(self.tmpfile.name)
         if hasattr(self, 'viewer'):
             if hasattr(self.viewer, "close"):
-                self.viewer.close(warn=False)
+                spec = getfullargspec(self.viewer.close)
+                kwargs = spec[4]
+                if "warn" in kwargs:
+                    self.viewer.close(warn=False)
+                else:
+                    self.viewer.close()
             self.viewer = None
         if hasattr(self, 'app'):
             if hasattr(self.app, 'close'):

--- a/glue_ar/common/tests/test_scatter.py
+++ b/glue_ar/common/tests/test_scatter.py
@@ -179,10 +179,13 @@ class BaseScatterTest:
             if hasattr(self.viewer, "close"):
                 spec = getfullargspec(self.viewer.close)
                 kwargs = spec[4]
-                if "warn" in kwargs:
-                    self.viewer.close(warn=False)
-                else:
-                    self.viewer.close()
+                try:
+                    if "warn" in kwargs:
+                        self.viewer.close(warn=False)
+                    else:
+                        self.viewer.close()
+                except NotImplementedError:
+                    pass
             self.viewer = None
         if hasattr(self, 'app'):
             if hasattr(self.app, 'close'):

--- a/glue_ar/common/usd_builder.py
+++ b/glue_ar/common/usd_builder.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from os import extsep, remove
-from os.path import splitext
+from os.path import exists, splitext
 
 from pxr import Usd, UsdGeom, UsdLux, UsdShade, UsdUtils
 from typing import Dict, Iterable, Optional, Tuple
@@ -117,6 +117,12 @@ class USDBuilder:
         base, ext = splitext(filepath)
         if ext == ".usdz":
             usdc_path = f"{base}{extsep}usdc"
+            usdc_exists = exists(usdc_path)
+            count = 0
+            while usdc_exists:
+                count += 1
+                usdc_path = f"{base}-{count}{extsep}usdc"
+                usdc_exists = exists(usdc_path)
             self.stage.GetRootLayer().Export(usdc_path)
             UsdUtils.CreateNewUsdzPackage(usdc_path, filepath)
             remove(usdc_path)
@@ -124,5 +130,4 @@ class USDBuilder:
             self.stage.GetRootLayer().Export(filepath)
 
     def build_and_export(self, filepath: str):
-        output_path = sanitize_path(filepath)
-        self.export(output_path)
+        self.export(filepath)

--- a/glue_ar/common/usd_builder.py
+++ b/glue_ar/common/usd_builder.py
@@ -16,15 +16,12 @@ MaterialInfo = Tuple[int, int, int, float, float, float]
 @builder(("usda", "usdc", "usdz"))
 class USDBuilder:
 
-    def __init__(self, filepath: str):
-        base, ext = splitext(filepath)
-        if ext == ".usdz":
-            filepath = f"{base}{extsep}usdc"
-        self._create_stage(filepath)
+    def __init__(self):
+        self._create_stage()
         self._material_map: Dict[MaterialInfo, UsdShade.Shader] = {}
 
-    def _create_stage(self, filepath: str):
-        self.stage = Usd.Stage.CreateNew(sanitize_path(filepath))
+    def _create_stage(self):
+        self.stage = Usd.Stage.CreateInMemory()
 
         # TODO: Do we want to make changing this an option?
         UsdGeom.SetStageUpAxis(self.stage, UsdGeom.Tokens.y)
@@ -127,4 +124,5 @@ class USDBuilder:
             self.stage.GetRootLayer().Export(filepath)
 
     def build_and_export(self, filepath: str):
-        self.export(filepath)
+        output_path = sanitize_path(filepath)
+        self.export(output_path)


### PR DESCRIPTION
Something that I hadn't realized until now is that we can create the USD stage directly in memory, rather than immediately passing in a filepath. I suspect that this was the cause of #78.

This PR updates our USD builder to create its stage in memory. This has the additional benefit of making all of our builders  have no-argument constructors.