### PR TITLE
Allow adding animations to glTF figures

### DIFF
--- a/glue_ar/common/gltf_animation.py
+++ b/glue_ar/common/gltf_animation.py
@@ -1,0 +1,91 @@
+from gltflib import AccessorType, ComponentType
+from struct import calcsize
+
+from ..gltf_utils import add_points_to_bytearray, add_values_to_bytearray
+from .gltf_builder import GLTFBuilder
+
+
+def one_hot_scales(length: int) -> tuple[tuple[int]]:
+    return tuple((1, 1, 1) if idx == (length-1) else (0, 0, 0) for idx in range(2*length-1))
+
+
+def set_up_flipbook_animation(
+    builder: GLTFBuilder,
+    n_snapshots: int,
+    time_delta: float = 0.05,
+    uri: str = "animation.bin",
+    animation_name: str = "Flipbook",
+    with_scales: bool = True,
+) -> dict:
+
+    timestamps = tuple(i * time_delta for i in range(1, n_snapshots))
+    buffer = bytearray()
+    add_values_to_bytearray(buffer, timestamps)
+    time_bytelen = len(buffer)
+    buffer_index = builder.buffer_count
+
+    if with_scales:
+        scale_accessor_indices = []
+        scales = one_hot_scales(n_snapshots)
+        add_points_to_bytearray(buffer, scales)
+        scale_mins = (0, 0, 0)
+        scale_maxes = (1, 1, 1)
+        scales_len = len(buffer) - time_bytelen
+        buffer_view_length = scales_len * n_snapshots // (2 * n_snapshots - 1)
+
+        float_size = calcsize("f")
+        for index in range(n_snapshots):
+        
+            offset = 3 * float_size * index + time_bytelen
+            builder.add_buffer_view(
+                buffer=buffer_index,
+                byte_length=buffer_view_length,
+                byte_offset=offset,
+            )
+            buffer_view = builder.buffer_view_count - 1
+            builder.add_accessor(
+                buffer_view=buffer_view,
+                component_type=ComponentType.FLOAT,
+                count=len(timestamps),
+                type=AccessorType.VEC3,
+                mins=scale_mins,
+                maxes=scale_maxes,
+            )
+            scale_accessor_indices.append(builder.accessor_count - 1)
+
+    builder.add_buffer(
+        byte_length=len(buffer),
+        uri=uri,
+    )
+    builder.add_file_resource(
+        filename=uri,
+        data=buffer,
+    )
+    builder.add_buffer_view(
+        buffer=buffer_index,
+        byte_length=time_bytelen,
+        byte_offset=0,
+    )
+
+    time_buffer_view_index = builder.buffer_view_count - 1
+    builder.add_accessor(
+        buffer_view=time_buffer_view_index,
+        component_type=ComponentType.FLOAT,
+        count=len(timestamps),
+        type=AccessorType.SCALAR,
+        mins=[min(timestamps)],
+        maxes=[max(timestamps)],
+    )
+    time_accessor_index = builder.accessor_count - 1
+
+    builder.add_animation(name=animation_name)
+    animation_index = builder.animation_count - 1
+
+    data = dict(
+        animation_index=animation_index,
+        time_accessor_index=time_accessor_index,
+    )
+    if with_scales:
+        data["scale_accessor_indices"] = scale_accessor_indices
+
+    return data

--- a/glue_ar/common/gltf_animation.py
+++ b/glue_ar/common/gltf_animation.py
@@ -35,7 +35,7 @@ def set_up_flipbook_animation(
 
         float_size = calcsize("f")
         for index in range(n_snapshots):
-        
+
             offset = 3 * float_size * index + time_bytelen
             builder.add_buffer_view(
                 buffer=buffer_index,

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -141,10 +141,16 @@ class GLTFBuilder:
         sampler = AnimationSampler(input=time_accessor, interpolation=interpolation, output=diffs_accessor)
         
         anim = self.animations[animation]
-        sampler_index = len(anim.samplers)
+        if anim.samplers is None:
+            anim.samplers = [sampler]
+        else:
+            anim.samplers.append(sampler)
+        sampler_index = len(anim.samplers) - 1
         channel = Channel(target=target, sampler=sampler_index)
-        anim.samplers.append(sampler)
-        anim.channels.append(channel)
+        if anim.channels is None:
+            anim.channels = [channel]
+        else:
+            anim.channels.append(channel)
         
         return self
 

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -89,12 +89,14 @@ class GLTFBuilder:
                         buffer: int,
                         byte_length: int,
                         byte_offset: int,
+                        byte_stride: Optional[int] = None,
                         target: Optional[BufferTarget] = None) -> GLTFBuilder:
         self.buffer_views.append(
             BufferView(
                 buffer=buffer,
                 byteLength=byte_length,
                 byteOffset=byte_offset,
+                byteStride=byte_stride,
                 target=target.value if target else None,
             )
         )

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -23,8 +23,6 @@ class GLTFBuilder:
         self.buffer_views: List[BufferView] = []
         self.accessors: List[Accessor] = []
         self.file_resources: List[FileResource] = []
-        self.channels: List[Channel] = []
-        self.samplers: List[AnimationSampler] = []
         self.animations: List[Animation] = []
 
     def add_material(self,
@@ -131,21 +129,34 @@ class GLTFBuilder:
         )
         return self
 
-    def add_animation(self,
-                      name: str,
-                      node: int,
-                      time_accessor: int,
-                      diffs_accessor: int,
-                      path: Literal["translation", "rotation", "scale"],
-                      interpolation: Literal["STEP", "LINEAR", "CUBICSPLINE"] = "LINEAR") -> GLTFBuilder:
+    def add_to_animation(self,
+                         animation: int,
+                         node: int,
+                         time_accessor: int,
+                         diffs_accessor: int,
+                         path: Literal["translation", "rotation", "scale"],
+                         interpolation: Literal["STEP", "LINEAR", "CUBICSPLINE"] = "LINEAR") -> GLTFBuilder:
 
         target = Target(node=node, path=path)
         sampler = AnimationSampler(input=time_accessor, interpolation=interpolation, output=diffs_accessor)
-        self.samplers.append(sampler)
-        channel = Channel(target=target, sampler=self.sampler_count-1)
-        self.channels.append(channel)
-        animation = Animation(name=name, channels=[channel], samplers=[sampler])
+        
+        anim = self.animations[animation]
+        sampler_index = len(anim.samplers)
+        channel = Channel(target=target, sampler=sampler_index)
+        anim.samplers.append(sampler)
+        anim.channels.append(channel)
+        
+        return self
+
+
+    def add_animation(self,
+                      name: str,
+                      channels: Optional[List[Channel]] = None,
+                      samplers: Optional[List[AnimationSampler]] = None) -> GLTFBuilder:
+
+        animation = Animation(name=name, channels=channels, samplers=samplers)
         self.animations.append(animation)
+        
         return self
 
     @property
@@ -169,14 +180,6 @@ class GLTFBuilder:
         return len(self.accessors)
 
     @property
-    def channel_count(self) -> int:
-        return len(self.channels)
-
-    @property
-    def sampler_count(self) -> int:
-        return len(self.samplers)
-
-    @property
     def animation_count(self) -> int:
         return len(self.animations)
 
@@ -193,7 +196,6 @@ class GLTFBuilder:
             bufferViews=self.buffer_views,
             accessors=self.accessors,
             materials=self.materials or None,
-            samplers=self.samplers or None,
             animations=self.animations or None,
         )
 

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -142,7 +142,7 @@ class GLTFBuilder:
 
         target = Target(node=node, path=path)
         sampler = AnimationSampler(input=time_accessor, interpolation=interpolation, output=values_accessor)
-        
+
         anim = self.animations[animation]
         if anim.samplers is None:
             anim.samplers = [sampler]
@@ -154,9 +154,8 @@ class GLTFBuilder:
             anim.channels = [channel]
         else:
             anim.channels.append(channel)
-        
-        return self
 
+        return self
 
     def add_animation(self,
                       name: str,
@@ -165,7 +164,7 @@ class GLTFBuilder:
 
         animation = Animation(name=name, channels=channels, samplers=samplers)
         self.animations.append(animation)
-        
+
         return self
 
     def add_extension(self,

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -204,7 +204,9 @@ class GLTFBuilder:
         nodes = [Node(mesh=i) for i in range(len(self.meshes))]
         node_indices = list(range(len(nodes)))
         scenes = [Scene(nodes=node_indices)]
-        return GLTFModel(
+        required_extensions = list(ext for ext, params in self.extensions.items() if params.get("required", True))
+        used_extensions = list(ext for ext, params in self.extensions.items() if params.get("used", True))
+        model_params = dict(
             asset=Asset(version="2.0"),
             scenes=scenes,
             nodes=nodes,
@@ -214,9 +216,12 @@ class GLTFBuilder:
             accessors=self.accessors,
             materials=self.materials or None,
             animations=self.animations or None,
-            extensionsRequired=list(ext for ext, params in self.extensions.items() if params.get("required", True)),
-            extensionsUsed=list(ext for ext, params in self.extensions.items() if params.get("used", True)),
         )
+        if required_extensions:
+            model_params["extensionsRequired"] = required_extensions
+        if used_extensions:
+            model_params["extensionsUsed"] = used_extensions
+        return GLTFModel(**model_params)
 
     def build(self) -> GLTF:
         model = self.build_model()

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -24,6 +24,7 @@ class GLTFBuilder:
         self.accessors: List[Accessor] = []
         self.file_resources: List[FileResource] = []
         self.animations: List[Animation] = []
+        self.extensions: Dict[str, Dict[str, bool]] = {}
 
     def add_material(self,
                      color: Iterable[float],
@@ -165,6 +166,15 @@ class GLTFBuilder:
         
         return self
 
+    def add_extension(self,
+                      extension: str,
+                      required: bool = True,
+                      used: bool = True) -> GLTFBuilder:
+        self.extensions[extension] = {
+            "required": required,
+            "used": used,
+        }
+
     @property
     def material_count(self) -> int:
         return len(self.materials)
@@ -203,6 +213,9 @@ class GLTFBuilder:
             accessors=self.accessors,
             materials=self.materials or None,
             animations=self.animations or None,
+            extensions=list(self.extensions.keys()),
+            extensionsRequired=list(ext for ext, params in self.extensions.items() if params.get("required", True)),
+            extensionsUsed=list(ext for ext, params in self.extensions.items() if params.get("used", True)),
         )
 
     def build(self) -> GLTF:

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -90,13 +90,13 @@ class GLTFBuilder:
                         buffer: int,
                         byte_length: int,
                         byte_offset: int,
-                        target: BufferTarget) -> GLTFBuilder:
+                        target: Optional[BufferTarget] = None) -> GLTFBuilder:
         self.buffer_views.append(
             BufferView(
                 buffer=buffer,
                 byteLength=byte_length,
                 byteOffset=byte_offset,
-                target=target.value,
+                target=target.value if target else None,
             )
         )
         return self

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -214,7 +214,6 @@ class GLTFBuilder:
             accessors=self.accessors,
             materials=self.materials or None,
             animations=self.animations or None,
-            extensions=list(self.extensions.keys()),
             extensionsRequired=list(ext for ext, params in self.extensions.items() if params.get("required", True)),
             extensionsUsed=list(ext for ext, params in self.extensions.items() if params.get("used", True)),
         )

--- a/glue_ar/common/gltf_builder.py
+++ b/glue_ar/common/gltf_builder.py
@@ -133,12 +133,12 @@ class GLTFBuilder:
                          animation: int,
                          node: int,
                          time_accessor: int,
-                         diffs_accessor: int,
+                         values_accessor: int,
                          path: Literal["translation", "rotation", "scale"],
                          interpolation: Literal["STEP", "LINEAR", "CUBICSPLINE"] = "LINEAR") -> GLTFBuilder:
 
         target = Target(node=node, path=path)
-        sampler = AnimationSampler(input=time_accessor, interpolation=interpolation, output=diffs_accessor)
+        sampler = AnimationSampler(input=time_accessor, interpolation=interpolation, output=values_accessor)
         
         anim = self.animations[animation]
         if anim.samplers is None:

--- a/glue_ar/common/tests/test_ranged_callback.py
+++ b/glue_ar/common/tests/test_ranged_callback.py
@@ -2,13 +2,13 @@ from glue.core.state_objects import State
 from glue_ar.common.ranged_callback import RangedCallbackProperty
 
 
-class TestState(State):
+class DummyRangedCallbackState(State):
     int_value = RangedCallbackProperty(default=10, min_value=5, max_value=25, resolution=1)
     float_value = RangedCallbackProperty(default=0.7, min_value=0.2, max_value=3.6, resolution=0.02)
 
 
 def test_ranged_callback():
-    state = TestState()
+    state = DummyRangedCallbackState()
 
     assert state.int_value == 10
     state.int_value = -4

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -28,7 +28,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
                           layer_states: Union[List[VolumeLayerState], VolumeLayerState],
                           options: Iterable[ARVoxelExportOptions],
                           bounds: Optional[BoundsWithResolution] = None,
-                          voxels_per_mesh: Optional[int] = None):
+                          voxels_per_mesh: Optional[int] = 1):
 
     if isinstance(layer_states, VolumeLayerState):
         layer_states = [layer_states]

--- a/glue_ar/gltf_utils.py
+++ b/glue_ar/gltf_utils.py
@@ -69,6 +69,11 @@ def add_triangles_to_bytearray(arr: bytearray,
             arr.extend(struct.pack(export_option.format, index))
 
 
+def add_values_to_bytearray(arr: bytearray, values: Iterable[Union[int, float]], format="f"):
+    for value in values:
+        arr.extend(struct.pack(format, value))
+
+
 T = TypeVar("T", bound=Union[int, float])
 
 

--- a/glue_ar/gltf_utils.py
+++ b/glue_ar/gltf_utils.py
@@ -55,10 +55,12 @@ def create_material_for_color(
     )
 
 
-def add_points_to_bytearray(arr: bytearray, points: Iterable[Iterable[Union[int, float]]]):
+def add_points_to_bytearray(arr: bytearray,
+                            points: Iterable[Iterable[Union[int, float]]],
+                            format: Literal["e", "f"] = "f"):
     for point in points:
         for coordinate in point:
-            arr.extend(struct.pack('f', coordinate))
+            arr.extend(struct.pack(format, coordinate))
 
 
 def add_triangles_to_bytearray(arr: bytearray,
@@ -69,7 +71,9 @@ def add_triangles_to_bytearray(arr: bytearray,
             arr.extend(struct.pack(export_option.format, index))
 
 
-def add_values_to_bytearray(arr: bytearray, values: Iterable[Union[int, float]], format="f"):
+def add_values_to_bytearray(arr: bytearray,
+                            values: Iterable[Union[int, float]],
+                            format: Literal["e", "f"] = "f"):
     for value in values:
         arr.extend(struct.pack(format, value))
 

--- a/glue_ar/gltf_utils.py
+++ b/glue_ar/gltf_utils.py
@@ -38,6 +38,7 @@ GLTF_COMPRESSION_EXTENSIONS = {
     "meshoptimizer": "EXT_meshopt_compression",
 }
 
+
 def byte_size_format(component_type: ComponentType | int) -> Tuple[int, str]:
     match component_type:
         case ComponentType.UNSIGNED_BYTE:
@@ -195,7 +196,6 @@ def get_vertex_positions(gltf: GLTF, mesh_index: int, primitive_index: int = 0):
     count = accessor.count
     component_type = accessor.componentType
     data_type = accessor.type
-
 
     if data_type != AccessorType.VEC3.value:
         raise ValueError(f"Vertex positions should be VEC3! Got {data_type}")


### PR DESCRIPTION
This PR sets up some functionality for adding animations in glTF figures. While we don't currently have a use case for this in glue (as glue generally doesn't support animation), I needed this functionality for another project and so incorporated it into the glTF builder in anticipation of needing animations in the future.

There are a few other items in here that popped up as well - the ability for us to directly specify which extensions we need, as well a few tweaks to open up some more options in the glTF utilities.