### PR TITLE
Fix swapped hrefs on Jupiter Cospace links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -290,7 +290,7 @@
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/QSH-BYT"
+                  href="https://edu.cospaces.io/AHF-YHL"
                   src="assets/img/qr/Jupiter_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Jupiter_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Jupiter_CoSpaces_tabletop_black.png'"
@@ -303,7 +303,7 @@
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/AHF-YHL"
+		  href="https://edu.cospaces.io/QSH-BYT"
                   src="assets/img/qr/Jupiter_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Jupiter_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Jupiter_CoSpaces_MERGE_black.png'"


### PR DESCRIPTION
The hyperlinks on for the Jupiter CoSpaces tabletop and MERGE Cube versions are flipped (the QR codes are correct, though). This PR fixes them.