### PR TITLE
Fix links to animated RadWave CoSpaces

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -478,11 +478,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/VFU-PZF">
+              <a class="image img-link" href="https://edu.cospaces.io/YYN-XJW">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/VFU-PZF"
+                  href="https://edu.cospaces.io/YYN-XJW"
                   src="assets/img/qr/Radcliffe Wave (animated)_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Radcliffe Wave (animated)_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Radcliffe Wave (animated)_CoSpaces_tabletop_black.png'"
@@ -491,11 +491,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/HTL-WPJ">
+              <a class="image img-link" href="https://edu.cospaces.io/ZKF-SKT">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/HTL-WPJ"
+                  href="https://edu.cospaces.io/ZKF-SKT"
                   src="assets/img/qr/Radcliffe Wave (animated)_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Radcliffe Wave (animated)_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Radcliffe Wave (animated)_CoSpaces_MERGE_black.png'"


### PR DESCRIPTION
As the title says, fix the links to the animated RadWave CoSpaces on the docs page. (The QR code inages are fine, but the actual link locations are not)