### PR TITLE
Update CoSpaces links to Delightex

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -113,7 +113,7 @@
       <p>Below are some examples of files generated using glue-ar. Scan the QR codes to see the figures in AR on your phone! We provide three types of interactives for most of our examples:</p>
       <ul>
         <li><strong><em>model-viewer</em></strong>: These use Google's <a href="https://modelviewer.dev/">model-viewer</a> web component to allow you to view figures in tabletop AR directly from your phone. No app required!</li>
-        <li><strong><em>CoSpaces - tabletop</em></strong>: These allow viewing the model in AR using <a href="https://www.cospaces.io/">CoSpaces</a> in a tabletop format. This method requires installing the CoSpaces app.</li>
+        <li><strong><em>CoSpaces - tabletop</em></strong>: These allow viewing the model in AR using <a href="https://www.delightex.com/">CoSpaces</a> in a tabletop format. This method requires installing the CoSpaces app.</li>
         <li><strong><em>CoSpaces - MERGE</em></strong>: These also use CoSpaces, but allow holding the model in your hand via the <a href="https://mergeedu.com/cube">MERGE Cube</a>. To use these, you can either buy a MERGE Cube, or create your own <a href="https://support.mergeedu.com/hc/en-us/articles/360052933492-Making-a-Merge-Paper-Cube">paper MERGE Cube</a>. This method requires installing the CoSpaces app.</li>
       </ul>
       <!-- 
@@ -142,11 +142,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/RBD-AXY">
+              <a class="image img-link" href="https://edu.delightex.com/RBD-AXY">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/RBD-AXY"
+                  href="https://edu.delightex.com/RBD-AXY"
                   src="assets/img/qr/PerTau shell_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/PerTau shell_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/PerTau shell_CoSpaces_tabletop_black.png'"
@@ -155,11 +155,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/YUQ-BKD">
+              <a class="image img-link" href="https://edu.delightex.com/YUQ-BKD">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/YUQ-BKD"
+                  href="https://edu.delightex.com/YUQ-BKD"
                   src="assets/img/qr/PerTau shell_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/PerTau shell_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/PerTau shell_CoSpaces_MERGE_black.png'"
@@ -190,11 +190,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/VFU-PZF">
+              <a class="image img-link" href="https://edu.delightex.com/VFU-PZF">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/VFU-PZF"
+                  href="https://edu.delightex.com/VFU-PZF"
                   src="assets/img/qr/Radcliffe Wave (static)_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Radcliffe Wave (static)_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Radcliffe Wave (static)_CoSpaces_tabletop_black.png'"
@@ -203,11 +203,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/HTL-WPJ">
+              <a class="image img-link" href="https://edu.delightex.com/HTL-WPJ">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/HTL-WPJ"
+                  href="https://edu.delightex.com/HTL-WPJ"
                   src="assets/img/qr/Radcliffe Wave (static)_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Radcliffe Wave (static)_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Radcliffe Wave (static)_CoSpaces_MERGE_black.png'"
@@ -238,11 +238,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/JUE-LPD">
+              <a class="image img-link" href="https://edu.delightex.com/JUE-LPD">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/JUE-LPD"
+                  href="https://edu.delightex.com/JUE-LPD"
                   src="assets/img/qr/Moon_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Moon_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Moon_CoSpaces_tabletop_black.png'"
@@ -251,11 +251,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/SNV-BWD">
+              <a class="image img-link" href="https://edu.delightex.com/SNV-BWD">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/SNV-BWD"
+                  href="https://edu.delightex.com/SNV-BWD"
                   src="assets/img/qr/Moon_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Moon_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Moon_CoSpaces_MERGE_black.png'"
@@ -286,11 +286,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/QSH-BYT">
+              <a class="image img-link" href="https://edu.delightex.com/QSH-BYT">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/AHF-YHL"
+                  href="https://edu.delightex.com/AHF-YHL"
                   src="assets/img/qr/Jupiter_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Jupiter_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Jupiter_CoSpaces_tabletop_black.png'"
@@ -299,11 +299,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/AHF-YHL">
+              <a class="image img-link" href="https://edu.delightex.com/AHF-YHL">
                 <img
                   class="qr-code"
                   width="25%"
-		  href="https://edu.cospaces.io/QSH-BYT"
+		  href="https://edu.delightex.com/QSH-BYT"
                   src="assets/img/qr/Jupiter_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Jupiter_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Jupiter_CoSpaces_MERGE_black.png'"
@@ -334,11 +334,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/ZZK-AJS">
+              <a class="image img-link" href="https://edu.delightex.com/ZZK-AJS">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/ZZK-AJS"
+                  href="https://edu.delightex.com/ZZK-AJS"
                   src="assets/img/qr/Local Bubble B field (vectors) + Gum Nebula_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Local Bubble B field (vectors) + Gum Nebula_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Local Bubble B field (vectors) + Gum Nebula_CoSpaces_tabletop_black.png'"
@@ -347,11 +347,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/HSB-EYR">
+              <a class="image img-link" href="https://edu.delightex.com/HSB-EYR">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/HSB-EYR"
+                  href="https://edu.delightex.com/HSB-EYR"
                   src="assets/img/qr/Local Bubble B field (vectors) + Gum Nebula_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Local Bubble B field (vectors) + Gum Nebula_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Local Bubble B field (vectors) + Gum Nebula_CoSpaces_MERGE_black.png'"
@@ -382,11 +382,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/JRS-JCK">
+              <a class="image img-link" href="https://edu.delightex.com/JRS-JCK">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/JRS-JCK"
+                  href="https://edu.delightex.com/JRS-JCK"
                   src="assets/img/qr/M83_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/M83_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/M83_CoSpaces_tabletop_black.png'"
@@ -395,11 +395,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/JSZ-RAR">
+              <a class="image img-link" href="https://edu.delightex.com/JSZ-RAR">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/JSZ-RAR"
+                  href="https://edu.delightex.com/JSZ-RAR"
                   src="assets/img/qr/M83_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/M83_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/M83_CoSpaces_MERGE_black.png'"
@@ -430,11 +430,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/ZKP-FGK">
+              <a class="image img-link" href="https://edu.delightex.com/ZKP-FGK">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/ZKP-FGK"
+                  href="https://edu.delightex.com/ZKP-FGK"
                   src="assets/img/qr/Gum Nebula + IRAS Vela Shell_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Gum Nebula + IRAS Vela Shell_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Gum Nebula + IRAS Vela Shell_CoSpaces_tabletop_black.png'"
@@ -443,11 +443,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/GCR-YCC">
+              <a class="image img-link" href="https://edu.delightex.com/GCR-YCC">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/GCR-YCC"
+                  href="https://edu.delightex.com/GCR-YCC"
                   src="assets/img/qr/Gum Nebula + IRAS Vela Shell_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Gum Nebula + IRAS Vela Shell_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Gum Nebula + IRAS Vela Shell_CoSpaces_MERGE_black.png'"
@@ -478,11 +478,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/YYN-XJW">
+              <a class="image img-link" href="https://edu.delightex.com/YYN-XJW">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/YYN-XJW"
+                  href="https://edu.delightex.com/YYN-XJW"
                   src="assets/img/qr/Radcliffe Wave (animated)_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Radcliffe Wave (animated)_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Radcliffe Wave (animated)_CoSpaces_tabletop_black.png'"
@@ -491,11 +491,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/ZKF-SKT">
+              <a class="image img-link" href="https://edu.delightex.com/ZKF-SKT">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/ZKF-SKT"
+                  href="https://edu.delightex.com/ZKF-SKT"
                   src="assets/img/qr/Radcliffe Wave (animated)_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Radcliffe Wave (animated)_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Radcliffe Wave (animated)_CoSpaces_MERGE_black.png'"
@@ -513,11 +513,11 @@
           </div>
           <div class="box highlight qr-highlight">
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/DYY-NVK">
+              <a class="image img-link" href="https://edu.delightex.com/DYY-NVK">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/DYY-NVK"
+                  href="https://edu.delightex.com/DYY-NVK"
                   src="assets/img/qr/Original PerTau_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Original PerTau_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Original PerTau_CoSpaces_tabletop_black.png'"
@@ -526,11 +526,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/WPP-QFX">
+              <a class="image img-link" href="https://edu.delightex.com/WPP-QFX">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/WPP-QFX"
+                  href="https://edu.delightex.com/WPP-QFX"
                   src="assets/img/qr/Original PerTau_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Original PerTau_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Original PerTau_CoSpaces_MERGE_black.png'"
@@ -561,11 +561,11 @@
               <div>model-viewer</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/VDE-TZG">
+              <a class="image img-link" href="https://edu.delightex.com/VDE-TZG">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/VDE-TZG"
+                  href="https://edu.delightex.com/VDE-TZG"
                   src="assets/img/qr/Milky Way 3D_CoSpaces_tabletop_black.png"
                   onmouseover="this.src='assets/img/qr/Milky Way 3D_CoSpaces_tabletop_red.png'"
                   onmouseout="this.src='assets/img/qr/Milky Way 3D_CoSpaces_tabletop_black.png'"
@@ -574,11 +574,11 @@
               <div>CoSpaces - tabletop</div>
             </div>
             <div class="qr-item">
-              <a class="image img-link" href="https://edu.cospaces.io/GLH-AMA">
+              <a class="image img-link" href="https://edu.delightex.com/GLH-AMA">
                 <img
                   class="qr-code"
                   width="25%"
-                  href="https://edu.cospaces.io/GLH-AMA"
+                  href="https://edu.delightex.com/GLH-AMA"
                   src="assets/img/qr/Milky Way 3D_CoSpaces_MERGE_black.png"
                   onmouseover="this.src='assets/img/qr/Milky Way 3D_CoSpaces_MERGE_red.png'"
                   onmouseout="this.src='assets/img/qr/Milky Way 3D_CoSpaces_MERGE_black.png'"
@@ -632,7 +632,7 @@
 
     <section id="cospaces" class="nav-item container">
       <h2>CoSpaces</h2>
-      <p>A popular option for sharing 3D files in augmented reality is <a href="https://www.cospaces.io/">CoSpaces</a>, which allows viewing 3D files on a mobile device via a dedicated app. The CoSpaces app allows viewing figures in AR on a flat surface directly, or using the <a href="https://mergeedu.com/cube">Merge Cube</a> to allow for a more tangible AR experience.</p>
+      <p>A popular option for sharing 3D files in augmented reality is <a href="https://www.delightex.com/">CoSpaces</a>, which allows viewing 3D files on a mobile device via a dedicated app. The CoSpaces app allows viewing figures in AR on a flat surface directly, or using the <a href="https://mergeedu.com/cube">Merge Cube</a> to allow for a more tangible AR experience.</p>
       <p>CoSpaces supports the glTF and glB formats, so it's possible to output from glue-ar and share via CoSpaces directly. It's our goal to eventually allow automatic CoSpaces upload, but for now sharing your AR figures to CoSpaces requires some manual steps (as well as a CoSpaces account).</p>
       <p>To create a scene with your newly-exported figure, do the following:</p>
       <ol>


### PR DESCRIPTION
We have a lot of `cospaces.io` links on the docs page. After the CoSpaces -> Delightex rebrand, these redirect to `delightex.com`, but we shouldn't count on that continuing. This PR updates our CoSpaces links to use the new Delightex domain.