### PR TITLE
Fix formatting of install command on webpage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -98,9 +98,9 @@
     <section id="installation" class="nav-item container">
       <h2>Installation</h2>
       <p>glue-ar is installable via pip:</p>
-  
-      <code>pip install glue-ar</code>
-  
+      <p>
+        <code>pip install glue-ar</code>
+      </p>
       <p>Installation requires Node.js to be installed on your system, as we currently use JavaScript packages for
       performing Draco and Meshopt glTF compression. (Having Node installed is all that you need - the npm/JS
       management relevant for the package is all handled by the package build process!).</p>


### PR DESCRIPTION
This PR fixes a small visual bug that was bothering me - the spacing above and below the install command is currently asymmetrical (it's almost zero below the command). This PR fixes that.