### PR TITLE
Fix minor issues with scatter glTF/glB exports

### DIFF
--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -5,6 +5,7 @@ from glue_vispy_viewers.common.viewer_state import Vispy3DViewerState
 from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
 from numpy import ndarray
 from numpy.linalg import norm
+import struct
 
 from typing import List, Literal, Optional, Tuple
 
@@ -331,6 +332,16 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
 
         start = 0
         triangles_accessor = builder.accessor_count - 1
+
+        # We always store point values as FLOAT, which has a size of 4 bytes.
+        # Since the total bytearray at this point may not be divisible by 4,
+        # we add a bit of padding.
+        # Note that this will be at most 3 bytes
+        float_size = 4
+        off = float_size - (len(barr) % float_size)
+        for _ in range(off):
+            barr.extend(struct.pack("B", 0))
+
         while start < n_points:
             mesh_points = [pt for pts in points[start:start+points_per_mesh] for pt in pts]
             barr_offset = len(barr)

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -312,10 +312,11 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
         index_format = index_export_option(max_triangle_index)
         triangles_start = len(barr)
         add_triangles_to_bytearray(barr, mesh_triangles, export_option=index_format)
-        triangles_len = len(barr)
+        triangles_end = len(barr)
+        triangles_len = triangles_end - triangles_start
         builder.add_buffer_view(
             buffer=buffer,
-            byte_length=triangles_len-triangles_start,
+            byte_length=triangles_len,
             byte_offset=triangles_start,
             target=BufferTarget.ELEMENT_ARRAY_BUFFER,
         )
@@ -429,11 +430,12 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
             index_format = index_export_option(max_triangle_index)
             triangles_start = len(barr)
             add_triangles_to_bytearray(barr, mesh_triangles, export_option=index_format)
-            triangles_len = len(barr)
+            triangles_end = len(barr)
+            triangles_len = triangles_end - triangles_start
 
             builder.add_buffer_view(
                 buffer=buffer,
-                byte_length=triangles_len-triangles_start,
+                byte_length=triangles_end-triangles_start,
                 byte_offset=triangles_start,
                 target=BufferTarget.ELEMENT_ARRAY_BUFFER,
             )

--- a/glue_ar/common/scatter_gltf.py
+++ b/glue_ar/common/scatter_gltf.py
@@ -446,7 +446,7 @@ def add_scatter_layer_gltf(builder: GLTFBuilder,
 
             builder.add_buffer_view(
                 buffer=buffer,
-                byte_length=triangles_end-triangles_start,
+                byte_length=triangles_len,
                 byte_offset=triangles_start,
                 target=BufferTarget.ELEMENT_ARRAY_BUFFER,
             )


### PR DESCRIPTION
This PR fixes two small issues with the exporting of scatter layer glTF/glB layers. Both of these issues can only happen if we have a "remainder" piece when performing mesh chunking, which is probably why I hadn't noticed these until now:

* We assign the incorrect length to the buffer view for the remainder triangles. Due to a variable that I had named confusingly, we were using the current length of the buffer, rather than the length of the triangles portion of the buffer.
* Since adding the remainder pieces of the buffer means that we're interleaving point and triangle data, it's possible that the accessor offset for the points (which are always 4-byte floats) is not a multiple of 4, since we pack vertex indices as the smallest integer type which will fit the highest index value. This PR fixes this by adding a small set of padding to properly align the buffer if necessary. Note that this will be at most 3 bytes per scatter layer.
