### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/glue_ar/__init__.py
+++ b/glue_ar/__init__.py
@@ -1,10 +1,8 @@
 from contextlib import suppress
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    pass
+
+__version__ = importlib.metadata.version('glue-ar')
 
 
 def setup_common():

--- a/glue_ar/common/tests/test_scatter_usd.py
+++ b/glue_ar/common/tests/test_scatter_usd.py
@@ -12,15 +12,22 @@ from glue_ar.usd_utils import material_for_mesh
 from glue_ar.utils import export_label_for_layer, hex_to_components, iterator_count, layers_to_export, xyz_bounds
 
 
+EXTENSION_OPTIONS = ("usda", "usdc", "usdz")
+
+TEST_OPTIONS = list((app_type, viewer_type, extension)
+               for (app_type, viewer_type), extension
+               in zip(APP_VIEWER_OPTIONS, EXTENSION_OPTIONS))
+
+
 class TestVispyScatterUSD(BaseScatterTest):
 
-    @pytest.mark.parametrize("app_type,viewer_type", APP_VIEWER_OPTIONS)
-    def test_basic_export(self, app_type: str, viewer_type: str):
+    @pytest.mark.parametrize("app_type,viewer_type,extension", TEST_OPTIONS)
+    def test_basic_export(self, app_type: str, viewer_type: str, extension: str):
         if app_type == "jupyter" and viewer_type == "vispy" and platform == "win32":
             return
         self.basic_setup(app_type, viewer_type)
         bounds = xyz_bounds(self.viewer.state, with_resolution=False)
-        self.tmpfile = NamedTemporaryFile(suffix=".usdc", delete=False)
+        self.tmpfile = NamedTemporaryFile(suffix=f".{extension}", delete=False)
         self.tmpfile.close()
         layer_states = [layer.state for layer in layers_to_export(self.viewer)]
         export_viewer(self.viewer.state,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ qt = [
 ]
 
 jupyter = [
-    "glue-jupyter",
+    "glue-jupyter<0.26",
     "ipyfilechooser",
     "ipyvuetify",
     "glue-vispy-viewers[jupyter]",


### PR DESCRIPTION
`pkg_resources` is no longer in `setuptools` so this PR switches to using `importlib.metadata` instead.

I've also pinned `glue-jupyter<0.26` for the time being and updated the USD scatter test to test all three filetypes.