### PR TITLE
Bump action versions

### DIFF
--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Deploy examples to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
 
   initial_checks:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       coverage: false
       envs: |
@@ -21,7 +21,7 @@ jobs:
 
   tests:
     needs: initial_checks
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       display: true
       coverage: codecov


### PR DESCRIPTION
We're getting CI warnings about using deprecated Node 20 runners, so it's time to bump some action versions.
