### PR TITLE
Respect cutting plane for voxel exports

### DIFF
--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from math import ceil
 
-from numpy import isfinite, argwhere, transpose
+from numpy import apply_along_axis, isfinite, argwhere, fromfunction, transpose
 from typing import Iterable, List, Optional, Union
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
@@ -71,7 +71,16 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
         isorange = isomax - isomin
         nonempty_indices = argwhere(data > isomin)
-
+        cut_plane = None
+        if getattr(viewer_state, "cut_enabled", False):
+            from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
+            cut_plane = cutting_plane_from_state(viewer_state)
+            if cut_plane is not None:
+                resolution_factors = [256 / bound[2] for bound in bounds]
+                cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
+                def cut_plane_index_check(indices):
+                    return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0
+            
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
 
@@ -80,7 +89,10 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
             voxel_colors = [[int(256 * float(c)) for c in vc[:3]] for vc in voxel_colors]
 
         for indices in nonempty_indices:
-            value = data[tuple(indices)]
+            index_tuple = tuple(indices)
+            if cut_plane is not None and cut_plane_index_check(index_tuple):
+                continue
+            value = data[index_tuple]
             t_voxel = (value - isomin) / isorange
             if t_voxel > 0 and hasattr(layer_state, 'stretch'):
                 t_voxel = layer_state.stretch_object([t_voxel], **layer_state.stretch_parameters)[0]

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -79,7 +79,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
                 resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
                 cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
                 def cut_plane_index_check(indices):
-                    return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0
+                    return cut_plane_coeffs[1] * indices[0] + cut_plane_coeffs[2] * indices[1] + cut_plane_coeffs[0] * indices[2] + cut_plane[3] > 0
             
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
@@ -302,7 +302,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
                 resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
                 cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
                 def cut_plane_index_check(indices):
-                    return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0
+                    return cut_plane_coeffs[1] * indices[0] + cut_plane_coeffs[2] * indices[1] + cut_plane_coeffs[0] * indices[2] + cut_plane[3] > 0
 
         color = layer_color(layer_state)
         color_components = hex_to_components(color)

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -294,6 +294,15 @@ def add_voxel_layers_usd(builder: USDBuilder,
 
         isorange = isomax - isomin
         nonempty_indices = argwhere(data - isomin > 0)
+        cut_plane = None
+        if getattr(viewer_state, "cut_enabled", False):
+            from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
+            cut_plane = cutting_plane_from_state(viewer_state)
+            if cut_plane is not None:
+                resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
+                cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
+                def cut_plane_index_check(indices):
+                    return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0
 
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
@@ -303,8 +312,10 @@ def add_voxel_layers_usd(builder: USDBuilder,
             voxel_colors = [[int(256 * float(c)) for c in vc[:3]] for vc in voxel_colors]
 
         for indices in nonempty_indices:
-
-            value = data[tuple(indices)]
+            index_tuple = tuple(indices)
+            if cut_plane is not None and cut_plane_index_check(index_tuple):
+                continue
+            value = data[index_tuple]
             t_voxel = (value - isomin) / isorange
             if t_voxel > 0 and hasattr(layer_state, 'stretch'):
                 t_voxel = layer_state.stretch_object([t_voxel], **layer_state.stretch_parameters)[0]

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from math import ceil
 
-from numpy import apply_along_axis, isfinite, argwhere, fromfunction, transpose
+from numpy import isfinite, argwhere, transpose
 from typing import Iterable, List, Optional, Union
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -76,7 +76,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
             from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
             cut_plane = cutting_plane_from_state(viewer_state)
             if cut_plane is not None:
-                resolution_factors = [256 / bound[2] for bound in bounds]
+                resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
                 cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
                 def cut_plane_index_check(indices):
                     return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0


### PR DESCRIPTION
This PR partially addresses #151 by updating voxel exports to respect the cutting plane. The approach here is straightforward - we can check the (clip space) coordinates of each voxel against the cutting plane, and discard the voxel if it's clipped by the plane.

This doesn't touch isosurface exports at all - those will likely be more complicated and so can be done in their own PR.