### PR TITLE
Respect cutting plane for isosurface exports

### DIFF
--- a/glue_ar/common/cut_plane.py
+++ b/glue_ar/common/cut_plane.py
@@ -1,0 +1,68 @@
+from typing import Callable, List
+
+from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
+from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
+
+from glue_ar.utils import BoundsWithResolution, set_bit_on
+
+
+def create_cut_plane_check(
+    viewer_state: VolumeViewerState3D,
+    bounds: BoundsWithResolution
+) -> Callable[[List[int]], bool]:
+    cut_plane = cutting_plane_from_state(viewer_state)
+    if cut_plane is None:
+        def check(_indices: List[int]):
+            return True
+        return check
+
+    resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
+    cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
+
+    def cut_plane_check(indices: List[int]):
+        return cut_plane_coeffs[1] * indices[0] + cut_plane_coeffs[2] * indices[1] + cut_plane_coeffs[0] * indices[2] + cut_plane[3] > 0
+
+    return cut_plane_check
+
+
+# TODO These types probably need adjustment
+def adjust_isosurface_for_cut_plane(
+    viewer_state: VolumeViewerState3D,
+    bounds: BoundsWithResolution,
+    points: List[List[float]],
+    triangles: List[List[int]]
+) -> [List[List[float]], List[List[int]]]:
+
+    cut_plane_check = create_cut_plane_check(viewer_state, bounds)
+
+    cut_plane = cutting_plane_from_state(viewer_state)
+
+    # First, determine which points will be retained
+    point_mappings = {}
+    mapped_index = 0
+    for index, point in enumerate(points):
+        if cut_plane_check(point): 
+            point_mappings[index] = mapped_index
+            mapped_index += 1
+
+    # Next, handle the triangles
+    # There are three cases:
+    # * All points are retained
+    #    - In this case, all we need to do is remap the triangle indices
+    # * No points are retained
+    #    - In this case we can just drop the triangle altogether
+    # * The triangle has at least one point retained, and at least one not retained
+
+
+    new_triangles = []
+    for triangle in triangles:
+        retained = [index in point_mappings for index in triangle]
+
+        if all(retained):
+            new_triangles.append([point_mappings[index] for index in triangle])
+        elif any(retained):
+           retained_count = sum(retained)
+           if retained_count == 1:
+               index = retained.index(True)
+               retained_index = triangle[index]
+               non_retained_indices = [idx for idx in triangle if idx != index]

--- a/glue_ar/common/cut_plane.py
+++ b/glue_ar/common/cut_plane.py
@@ -7,14 +7,17 @@ from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
 from glue_ar.utils import BoundsWithResolution
 
 
+__all__ = ["create_cut_plane_check", "apply_cut_plane_to_isosurface"]
+
+
 def create_cut_plane_check(
     viewer_state: VolumeViewerState3D,
     bounds: BoundsWithResolution,
     index_permutation=None,
-) -> Callable[[List[int]], bool]:
+) -> Callable[[List[int | float]], bool]:
     cut_plane = cutting_plane_from_state(viewer_state)
     if cut_plane is None:
-        def check(_indices: List[int]):
+        def check(indices: List[int | float]) -> bool:
             return True
         return check
 
@@ -23,7 +26,12 @@ def create_cut_plane_check(
 
     cids = index_permutation or [1, 2, 0]
 
-    def cut_plane_check(indices: List[int]):
+    def cut_plane_check(indices: List[int | float]) -> bool:
+        print([cut_plane_coeffs[c] for c in cids])
+        print(indices)
+        print(cut_plane[3])
+        print(cut_plane_coeffs[cids[0]] * indices[0] + cut_plane_coeffs[cids[1]] * indices[1] + cut_plane_coeffs[cids[2]] * indices[2] + cut_plane[3])
+        print(cut_plane_coeffs[cids[0]] * indices[0] + cut_plane_coeffs[cids[1]] * indices[1] + cut_plane_coeffs[cids[2]] * indices[2] + cut_plane[3] > 0)
         return cut_plane_coeffs[cids[0]] * indices[0] + cut_plane_coeffs[cids[1]] * indices[1] + cut_plane_coeffs[cids[2]] * indices[2] + cut_plane[3] > 0
 
     return cut_plane_check
@@ -41,8 +49,7 @@ def _intersection_point(retained, discarded, cut_plane):
     return [r * (1 - t) + d * t for r, d in zip(retained, discarded)]
 
 
-# TODO These types probably need adjustment
-def adjust_isosurface_for_cut_plane(
+def apply_cut_plane_to_isosurface(
     viewer_state: VolumeViewerState3D,
     bounds: BoundsWithResolution,
     points: List[List[float]] | ndarray,

--- a/glue_ar/common/cut_plane.py
+++ b/glue_ar/common/cut_plane.py
@@ -27,11 +27,6 @@ def create_cut_plane_check(
     cids = index_permutation or [1, 2, 0]
 
     def cut_plane_check(indices: List[int | float]) -> bool:
-        print([cut_plane_coeffs[c] for c in cids])
-        print(indices)
-        print(cut_plane[3])
-        print(cut_plane_coeffs[cids[0]] * indices[0] + cut_plane_coeffs[cids[1]] * indices[1] + cut_plane_coeffs[cids[2]] * indices[2] + cut_plane[3])
-        print(cut_plane_coeffs[cids[0]] * indices[0] + cut_plane_coeffs[cids[1]] * indices[1] + cut_plane_coeffs[cids[2]] * indices[2] + cut_plane[3] > 0)
         return cut_plane_coeffs[cids[0]] * indices[0] + cut_plane_coeffs[cids[1]] * indices[1] + cut_plane_coeffs[cids[2]] * indices[2] + cut_plane[3] > 0
 
     return cut_plane_check

--- a/glue_ar/common/cut_plane.py
+++ b/glue_ar/common/cut_plane.py
@@ -25,6 +25,17 @@ def create_cut_plane_check(
     return cut_plane_check
 
 
+def _dot(p1, p2):
+    return sum(c1 * c2 for c1, c2 in zip(p1, p2))
+
+
+def _intersection_point(retained, discarded, cut_plane):
+    coeffs = cut_plane[:3]
+    diff = [r - d for r, d in zip(retained, discarded)]
+    t = -(cut_plane[3] + _dot(coeffs, retained)) / _dot(coeffs, diff)
+    return [r * (1 - t) + d * t for r, d in zip(retained, discarded)]
+
+
 # TODO These types probably need adjustment
 def adjust_isosurface_for_cut_plane(
     viewer_state: VolumeViewerState3D,
@@ -36,6 +47,8 @@ def adjust_isosurface_for_cut_plane(
     cut_plane_check = create_cut_plane_check(viewer_state, bounds)
 
     cut_plane = cutting_plane_from_state(viewer_state)
+    resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
+    cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
 
     # First, determine which points will be retained
     point_mappings = {}
@@ -53,16 +66,56 @@ def adjust_isosurface_for_cut_plane(
     #    - In this case we can just drop the triangle altogether
     # * The triangle has at least one point retained, and at least one not retained
 
-
     new_triangles = []
+    cut_coeffs = cut_plane_coeffs[:3] + [cut_plane[3]]
     for triangle in triangles:
         retained = [index in point_mappings for index in triangle]
+        retained_count = sum(retained)
 
-        if all(retained):
-            new_triangles.append([point_mappings[index] for index in triangle])
-        elif any(retained):
-           retained_count = sum(retained)
-           if retained_count == 1:
-               index = retained.index(True)
-               retained_index = triangle[index]
-               non_retained_indices = [idx for idx in triangle if idx != index]
+        match retained_count:
+            case 3:
+                new_triangles.append([point_mappings[index] for index in triangle])
+            case 1:
+                index = retained.index(True)
+                retained_index = triangle[index]
+                retained_point = points[triangle[retained_index]]
+                non_retained_indices = [idx for idx in triangle if idx != index]
+                non_retained_points = [points[triangle[idx]] for idx in non_retained_indices]
+
+                qs = [_intersection_point(retained_point, pt, cut_coeffs) for pt in non_retained_points]
+                points.extend(qs)
+                n = len(points)
+                point_mappings[n-1] = mapped_index
+                point_mappings[n] = mapped_index + 1
+                mapped_index += 2
+                new_triangle = [n-1, n]
+                new_triangle.insert(index, point_mappings[retained_index])
+                new_triangles.append(new_triangle)
+            case 2:
+                non_retained_index = retained.index(False)
+
+                # Move the non-retained index to the end for simplicity
+                shift = 2 - non_retained_index
+                shifted_triangle = triangle[shift:] + triangle[:shift]
+                shifted_pts = [points[idx] for idx in shifted_triangle]
+                q02 = _intersection_point(shifted_pts[0], shifted_pts[2], cut_coeffs)
+                q12 = _intersection_point(shifted_pts[1], shifted_pts[2], cut_coeffs)
+
+                points.append(q02)
+                points.append(q12)
+                n = len(points)
+                point_mappings[n-1] = mapped_index
+                point_mappings[n] = mapped_index + 1
+                mapped_index += 2
+                new_triangles.append([shifted_triangle[0], shifted_triangle[1], n-1])
+                new_triangles.append([shifted_triangle[1], n, n-1])
+
+
+        new_points = []
+        for index, point in enumerate(points):
+            mapped = point_mappings.get(index, None)
+            if mapped is not None:
+                new_points.append(points[mapped])
+
+        return new_points, new_triangles
+

--- a/glue_ar/common/cut_plane.py
+++ b/glue_ar/common/cut_plane.py
@@ -1,4 +1,5 @@
 from typing import Callable, List
+from numpy import roll, ndarray
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
@@ -8,7 +9,8 @@ from glue_ar.utils import BoundsWithResolution, set_bit_on
 
 def create_cut_plane_check(
     viewer_state: VolumeViewerState3D,
-    bounds: BoundsWithResolution
+    bounds: BoundsWithResolution,
+    index_permutation=None,
 ) -> Callable[[List[int]], bool]:
     cut_plane = cutting_plane_from_state(viewer_state)
     if cut_plane is None:
@@ -19,8 +21,10 @@ def create_cut_plane_check(
     resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
     cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
 
+    cids = index_permutation or [1, 2, 0]
+
     def cut_plane_check(indices: List[int]):
-        return cut_plane_coeffs[1] * indices[0] + cut_plane_coeffs[2] * indices[1] + cut_plane_coeffs[0] * indices[2] + cut_plane[3] > 0
+        return cut_plane_coeffs[cids[0]] * indices[0] + cut_plane_coeffs[cids[1]] * indices[1] + cut_plane_coeffs[cids[2]] * indices[2] + cut_plane[3] > 0
 
     return cut_plane_check
 
@@ -31,7 +35,8 @@ def _dot(p1, p2):
 
 def _intersection_point(retained, discarded, cut_plane):
     coeffs = cut_plane[:3]
-    diff = [r - d for r, d in zip(retained, discarded)]
+    coeffs = [coeffs[1], coeffs[2], coeffs[0]]
+    diff = [d - r for r, d in zip(retained, discarded)]
     t = -(cut_plane[3] + _dot(coeffs, retained)) / _dot(coeffs, diff)
     return [r * (1 - t) + d * t for r, d in zip(retained, discarded)]
 
@@ -40,8 +45,8 @@ def _intersection_point(retained, discarded, cut_plane):
 def adjust_isosurface_for_cut_plane(
     viewer_state: VolumeViewerState3D,
     bounds: BoundsWithResolution,
-    points: List[List[float]],
-    triangles: List[List[int]]
+    points: List[List[float]] | ndarray,
+    triangles: List[List[int]] | ndarray,
 ) -> [List[List[float]], List[List[int]]]:
 
     cut_plane_check = create_cut_plane_check(viewer_state, bounds)
@@ -49,6 +54,12 @@ def adjust_isosurface_for_cut_plane(
     cut_plane = cutting_plane_from_state(viewer_state)
     resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
     cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
+
+    if not isinstance(points, list):
+        points = points.tolist()
+
+    if not isinstance(triangles, list):
+        triangles = triangles.tolist()
 
     # First, determine which points will be retained
     point_mappings = {}
@@ -71,7 +82,6 @@ def adjust_isosurface_for_cut_plane(
     for triangle in triangles:
         retained = [index in point_mappings for index in triangle]
         retained_count = sum(retained)
-        print(retained_count)
 
         match retained_count:
             case 3:
@@ -79,17 +89,17 @@ def adjust_isosurface_for_cut_plane(
             case 1:
                 index = retained.index(True)
                 retained_index = triangle[index]
-                retained_point = points[triangle[retained_index]]
-                non_retained_indices = [idx for idx in triangle if idx != index]
-                non_retained_points = [points[triangle[idx]] for idx in non_retained_indices]
+                retained_point = points[retained_index]
+                non_retained_indices = [triangle[idx] for idx in range(3) if idx != index]
+                non_retained_points = [points[idx] for idx in non_retained_indices]
 
                 qs = [_intersection_point(retained_point, pt, cut_coeffs) for pt in non_retained_points]
                 points.extend(qs)
                 n = len(points)
-                point_mappings[n-1] = mapped_index
-                point_mappings[n] = mapped_index + 1
+                point_mappings[n-2] = mapped_index
+                point_mappings[n-1] = mapped_index + 1
+                new_triangle = [mapped_index, mapped_index + 1]
                 mapped_index += 2
-                new_triangle = [n-1, n]
                 new_triangle.insert(index, point_mappings[retained_index])
                 new_triangles.append(new_triangle)
             case 2:
@@ -97,7 +107,7 @@ def adjust_isosurface_for_cut_plane(
 
                 # Move the non-retained index to the end for simplicity
                 shift = 2 - non_retained_index
-                shifted_triangle = triangle[shift:] + triangle[:shift]
+                shifted_triangle = roll(triangle, shift)
                 shifted_pts = [points[idx] for idx in shifted_triangle]
                 q02 = _intersection_point(shifted_pts[0], shifted_pts[2], cut_coeffs)
                 q12 = _intersection_point(shifted_pts[1], shifted_pts[2], cut_coeffs)
@@ -105,18 +115,17 @@ def adjust_isosurface_for_cut_plane(
                 points.append(q02)
                 points.append(q12)
                 n = len(points)
-                point_mappings[n-1] = mapped_index
-                point_mappings[n] = mapped_index + 1
+                point_mappings[n-2] = mapped_index
+                point_mappings[n-1] = mapped_index + 1
+                new_triangles.append([point_mappings[shifted_triangle[0]], point_mappings[shifted_triangle[1]], mapped_index])
+                new_triangles.append([point_mappings[shifted_triangle[1]], mapped_index + 1, mapped_index])
                 mapped_index += 2
-                new_triangles.append([shifted_triangle[0], shifted_triangle[1], n-1])
-                new_triangles.append([shifted_triangle[1], n, n-1])
 
 
     new_points = []
     for index, point in enumerate(points):
-        mapped = point_mappings.get(index, None)
-        if mapped is not None:
-            new_points.append(points[mapped])
+        if index in point_mappings:
+            new_points.append(point)
 
     return new_points, new_triangles
 

--- a/glue_ar/common/cut_plane.py
+++ b/glue_ar/common/cut_plane.py
@@ -70,12 +70,20 @@ def adjust_isosurface_for_cut_plane(
             mapped_index += 1
 
     # Next, handle the triangles
-    # There are three cases:
+    # There are four cases:
     # * All points are retained
     #    - In this case, all we need to do is remap the triangle indices
     # * No points are retained
     #    - In this case we can just drop the triangle altogether
-    # * The triangle has at least one point retained, and at least one not retained
+    # * The triangle has exactly one point retained
+    #    - In this case the unclipped portion of the original triangle will be a new triangle
+    #      whose vertices are the unclipped vertex and the points where the edges out from the
+    #      unclipped vertex intersect the cutting plane. So we replace the original triangle
+    #      with the new triangle formed by these three points and respecting the original orientation
+    # * The triangle has exactly one point clipped
+    #    - In this case we find the intersection points with the cutting plane as above, but now the
+    #      unclipped region is a quadrilateral. So we replace the original triangle with two triangles
+    #      that form the quadrilateral and respect the original triangle's orientation
 
     new_triangles = []
     cut_coeffs = cut_plane_coeffs[:3] + [cut_plane[3]]

--- a/glue_ar/common/cut_plane.py
+++ b/glue_ar/common/cut_plane.py
@@ -71,6 +71,7 @@ def adjust_isosurface_for_cut_plane(
     for triangle in triangles:
         retained = [index in point_mappings for index in triangle]
         retained_count = sum(retained)
+        print(retained_count)
 
         match retained_count:
             case 3:
@@ -111,11 +112,11 @@ def adjust_isosurface_for_cut_plane(
                 new_triangles.append([shifted_triangle[1], n, n-1])
 
 
-        new_points = []
-        for index, point in enumerate(points):
-            mapped = point_mappings.get(index, None)
-            if mapped is not None:
-                new_points.append(points[mapped])
+    new_points = []
+    for index, point in enumerate(points):
+        mapped = point_mappings.get(index, None)
+        if mapped is not None:
+            new_points.append(points[mapped])
 
-        return new_points, new_triangles
+    return new_points, new_triangles
 

--- a/glue_ar/common/cut_plane.py
+++ b/glue_ar/common/cut_plane.py
@@ -4,7 +4,7 @@ from numpy import roll, ndarray
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
 
-from glue_ar.utils import BoundsWithResolution, set_bit_on
+from glue_ar.utils import BoundsWithResolution
 
 
 def create_cut_plane_check(
@@ -65,7 +65,7 @@ def adjust_isosurface_for_cut_plane(
     point_mappings = {}
     mapped_index = 0
     for index, point in enumerate(points):
-        if cut_plane_check(point): 
+        if not cut_plane_check(point):
             point_mappings[index] = mapped_index
             mapped_index += 1
 
@@ -128,4 +128,3 @@ def adjust_isosurface_for_cut_plane(
             new_points.append(point)
 
     return new_points, new_triangles
-

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -6,7 +6,6 @@ from gltflib import AccessorType, BufferTarget, ComponentType
 from glue.viewers.volume3d.layer_state import VolumeLayerState3D
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
-from glue_ar.common.cut_plane import apply_cut_plane_to_isosurface
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.stl_builder import STLBuilder
@@ -50,6 +49,10 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
     sides = tuple(sides[i] for i in (2, 1, 0))
 
     using_cut_plane = getattr(viewer_state, "cut_enabled", False)
+    if using_cut_plane:
+        from glue_ar.common.cut_plane import apply_cut_plane_to_isosurface
+    else:
+        apply_cut_plane_to_isosurface = None
 
     for level in levels[1:-1]:
         barr = bytearray()
@@ -59,7 +62,7 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
         if len(points) == 0:
             continue
 
-        if using_cut_plane:
+        if using_cut_plane and apply_cut_plane_to_isosurface:
             points, triangles = apply_cut_plane_to_isosurface(viewer_state, bounds, points, triangles)
             if len(points) == 0:
                 continue
@@ -162,6 +165,10 @@ def add_isosurface_layer_usd(
     sides = tuple(sides[i] for i in (2, 1, 0))
 
     using_cut_plane = getattr(viewer_state, "cut_enabled", False)
+    if using_cut_plane:
+        from glue_ar.common.cut_plane import apply_cut_plane_to_isosurface
+    else:
+        apply_cut_plane_to_isosurface = None
 
     for level in levels[1:-1]:
         alpha = layer_state.alpha * level
@@ -169,7 +176,7 @@ def add_isosurface_layer_usd(
         if len(points) == 0:
             continue
 
-        if using_cut_plane:
+        if using_cut_plane and apply_cut_plane_to_isosurface:
             points, triangles = apply_cut_plane_to_isosurface(viewer_state, bounds, points, triangles)
             if len(points) == 0:
                 continue

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -61,6 +61,8 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
 
         if using_cut_plane:
             points, triangles = adjust_isosurface_for_cut_plane(viewer_state, bounds, points, triangles)
+            if len(points) == 0:
+                continue
 
         opacity = layer_state.alpha * level
         if layer_state.color_mode == "Fixed":
@@ -159,11 +161,18 @@ def add_isosurface_layer_usd(
     sides = clip_sides(viewer_state, clip_size=1)
     sides = tuple(sides[i] for i in (2, 1, 0))
 
+    using_cut_plane = getattr(viewer_state, "cut_enabled", False)
+
     for level in levels[1:-1]:
         alpha = layer_state.alpha * level
         points, triangles = marching_cubes(data, level)
         if len(points) == 0:
             continue
+
+        if using_cut_plane:
+            points, triangles = adjust_isosurface_for_cut_plane(viewer_state, bounds, points, triangles)
+            if len(points) == 0:
+                continue
 
         if layer_state.color_mode == "Fixed":
             surface_color_components = color_components

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -6,7 +6,7 @@ from gltflib import AccessorType, BufferTarget, ComponentType
 from glue.viewers.volume3d.layer_state import VolumeLayerState3D
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
-from glue_ar.common.cut_plane import adjust_isosurface_for_cut_plane
+from glue_ar.common.cut_plane import apply_cut_plane_to_isosurface
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.stl_builder import STLBuilder
@@ -60,7 +60,7 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
             continue
 
         if using_cut_plane:
-            points, triangles = adjust_isosurface_for_cut_plane(viewer_state, bounds, points, triangles)
+            points, triangles = apply_cut_plane_to_isosurface(viewer_state, bounds, points, triangles)
             if len(points) == 0:
                 continue
 
@@ -170,7 +170,7 @@ def add_isosurface_layer_usd(
             continue
 
         if using_cut_plane:
-            points, triangles = adjust_isosurface_for_cut_plane(viewer_state, bounds, points, triangles)
+            points, triangles = apply_cut_plane_to_isosurface(viewer_state, bounds, points, triangles)
             if len(points) == 0:
                 continue
 

--- a/glue_ar/common/marching_cubes.py
+++ b/glue_ar/common/marching_cubes.py
@@ -6,6 +6,7 @@ from gltflib import AccessorType, BufferTarget, ComponentType
 from glue.viewers.volume3d.layer_state import VolumeLayerState3D
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
+from glue_ar.common.cut_plane import adjust_isosurface_for_cut_plane
 from glue_ar.common.export_options import ar_layer_export
 from glue_ar.common.gltf_builder import GLTFBuilder
 from glue_ar.common.stl_builder import STLBuilder
@@ -48,6 +49,8 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
     sides = clip_sides(viewer_state, clip_size=1)
     sides = tuple(sides[i] for i in (2, 1, 0))
 
+    using_cut_plane = getattr(viewer_state, "cut_enabled", False)
+
     for level in levels[1:-1]:
         barr = bytearray()
         level_bin = f"layer_{layer_state.layer.uuid}_level_{level}.bin"
@@ -55,6 +58,9 @@ def add_isosurface_layer_gltf(builder: GLTFBuilder,
         points, triangles = marching_cubes(data, level)
         if len(points) == 0:
             continue
+
+        if using_cut_plane:
+            points, triangles = adjust_isosurface_for_cut_plane(viewer_state, bounds, points, triangles)
 
         opacity = layer_state.alpha * level
         if layer_state.color_mode == "Fixed":

--- a/glue_ar/common/tests/test_cut_plane.py
+++ b/glue_ar/common/tests/test_cut_plane.py
@@ -1,7 +1,7 @@
 import inspect
 from itertools import product
-from math import ceil
 import pytest
+from typing import List
 
 try:
     from glue_vispy_viewers.volume.viewer_state import Vispy3DVolumeViewerState, cutting_plane_from_state
@@ -43,19 +43,19 @@ def test_cut_plane_check_simple(index_permutation, cut_depth, cut_axis):
     zeros = [0.0, 0.0, 0.0]
     nonzero_index = ["X", "Y", "Z"].index(cut_axis)
     first_clipped = list(zeros)
-    first_clipped[nonzero_index] = -ceil((cp[3] - 1) / cp[nonzero_index])
+    first_clipped[nonzero_index] = -(cp[3] - 1) / cp[nonzero_index]
     first_clipped = _permute_list(first_clipped, index_permutation)
     assert check(first_clipped)
 
     first_retained = list(zeros)
-    first_retained[nonzero_index] = -ceil(2 * cp[3] / cp[nonzero_index])
+    first_retained[nonzero_index] = -2 * cp[3] / cp[nonzero_index]
     if cp[3] < 0:
         first_retained[nonzero_index] *= -1
     first_retained = _permute_list(first_retained, index_permutation)
     assert not check(first_retained)
 
     second_clipped = list(zeros)
-    second_clipped[nonzero_index] = ceil(cp[3] / cp[nonzero_index])
+    second_clipped[nonzero_index] = cp[3] / cp[nonzero_index]
     if cp[3] < 0:
         second_clipped[nonzero_index] = -(second_clipped[nonzero_index] - 1)
     second_clipped = _permute_list(second_clipped, index_permutation)
@@ -65,7 +65,7 @@ def test_cut_plane_check_simple(index_permutation, cut_depth, cut_axis):
     zero_indices = [idx for idx in range(3) if idx != nonzero_index]
     second_retained[zero_indices[0]] = 3
     second_retained[zero_indices[1]] = 2
-    second_retained[nonzero_index] = -ceil((cp[3] - 3 * cp[zero_indices[0]] - 2 * cp[zero_indices[1]]) / cp[nonzero_index])
+    second_retained[nonzero_index] = -(cp[3] - 3 * cp[zero_indices[0]] - 2 * cp[zero_indices[1]]) / cp[nonzero_index]
     second_retained = _permute_list(second_retained, index_permutation)
     assert not check(second_retained)
 
@@ -91,23 +91,24 @@ def test_cut_plane_check_advanced(index_permutation, cut_depth, cut_tilt, cut_ro
     cp = cutting_plane_from_state(viewer_state)
     assert cp is not None
 
-    check = create_cut_plane_check(viewer_state, bounds)
-    first_clipped = _permute_list([0.0, 0.0, -ceil((cp[3] - 1) / cp[2])], index_permutation)
+    check = create_cut_plane_check(viewer_state, bounds, index_permutation=index_permutation)
+    first_clipped = [0.0, 0.0, (1 - cp[3]) / cp[2]]
+    first_clipped = _permute_list(first_clipped, index_permutation)
     assert check(first_clipped)
 
-    first_retained = [0.0, -ceil(2 * cp[3] / cp[1]), 0.0]
+    first_retained = [0.0, -2 * cp[3] / cp[1], 0.0]
     if cp[3] < 0:
         first_retained[1] *= -1
     first_retained = _permute_list(first_retained, index_permutation)
     assert not check(first_retained)
 
-    second_clipped = [0.0, 0.0, ceil(cp[3] / cp[2])]
+    second_clipped = [0.0, 0.0, cp[3] / cp[2]]
     if cp[3] < 0:
         second_clipped[2] = -(second_clipped[2] - 1)
     second_clipped = _permute_list(second_clipped, index_permutation)
     assert check(second_clipped)
 
-    second_retained = [-ceil((1 + cp[3] - 3 * cp[1] - 2 * cp[2]) / cp[0]), 3.0, 2.0]
+    second_retained = [-(1 + cp[3] - 3 * cp[1] - 2 * cp[2] / cp[0]), 3.0, 2.0]
     if cp[0] > 0:
         second_retained[0] *= -1
     second_retained = _permute_list(second_retained, index_permutation)
@@ -128,7 +129,7 @@ def test_cut_plane_check_type(index_permutation, cut_enabled):
     signature = inspect.signature(check)
     assert signature.return_annotation is bool
     assert "indices" in signature.parameters
-    assert signature.parameters["indices"] is int
+    assert signature.parameters["indices"].annotation is List[int | float]
 
 
 @pytest.mark.parametrize("index_permutation",
@@ -185,9 +186,9 @@ def test_apply_cut_plane_to_isosurface():
     new_points, new_triangles = apply_cut_plane_to_isosurface(viewer_state, bounds, points, triangles)
 
     # (4 retained points)
-    # + (2 new points from triangles 3 & 4)
+    # + (2 new points each from triangles 3 & 4)
     # + (2 new points each from triangles 4 & 5)
-    assert len(new_points) == 4 + 2 + 2 * 2
+    assert len(new_points) == 4 + (2 * 2) + (2 * 2)
 
     # 7 retained triangles
     # + 1 new triangle each from triangles 5 & 6

--- a/glue_ar/common/tests/test_cut_plane.py
+++ b/glue_ar/common/tests/test_cut_plane.py
@@ -1,0 +1,194 @@
+import inspect
+from itertools import product
+from math import ceil
+import pytest
+
+try:
+    from glue_vispy_viewers.volume.viewer_state import Vispy3DVolumeViewerState, cutting_plane_from_state
+    CUTTING_PLANE_AVAILABLE = True
+except ImportError:
+    CUTTING_PLANE_AVAILABLE = False
+
+if not CUTTING_PLANE_AVAILABLE:
+    pytest.skip("Cutting plane functionality is not available", allow_module_level=True)
+
+from glue_ar.common.cut_plane import create_cut_plane_check, apply_cut_plane_to_isosurface
+from glue_ar.utils import xyz_bounds
+
+
+def _permute_list(lst: list[float], permutation: list[int]) -> list[float]:
+    return [lst[c] for c in permutation]
+
+
+@pytest.mark.parametrize("index_permutation,cut_depth,cut_axis",
+                         product([None, [1, 0, 2], [1, 2, 0], [2, 0, 1]],
+                                 [0.0, 0.2, 0.5, 0.7],
+                                 ["X", "Y", "Z"]))
+def test_cut_plane_check_simple(index_permutation, cut_depth, cut_axis):
+    viewer_state = Vispy3DVolumeViewerState()
+    viewer_state.cut_enabled = True
+    viewer_state.cut_depth = cut_depth
+    viewer_state.resolution = 128
+    viewer_state.cut_mode = "Simple"
+    viewer_state.cut_axis = cut_axis
+
+    bounds = xyz_bounds(viewer_state, with_resolution=True)
+
+    index_permutation = index_permutation or [1, 2, 0]
+
+    cp = cutting_plane_from_state(viewer_state)
+    assert cp is not None
+
+    check = create_cut_plane_check(viewer_state, bounds, index_permutation=index_permutation)
+    zeros = [0.0, 0.0, 0.0]
+    nonzero_index = ["X", "Y", "Z"].index(cut_axis)
+    first_clipped = list(zeros)
+    first_clipped[nonzero_index] = -ceil((cp[3] - 1) / cp[nonzero_index])
+    first_clipped = _permute_list(first_clipped, index_permutation)
+    assert check(first_clipped)
+
+    first_retained = list(zeros)
+    first_retained[nonzero_index] = -ceil(2 * cp[3] / cp[nonzero_index])
+    if cp[3] < 0:
+        first_retained[nonzero_index] *= -1
+    first_retained = _permute_list(first_retained, index_permutation)
+    assert not check(first_retained)
+
+    second_clipped = list(zeros)
+    second_clipped[nonzero_index] = ceil(cp[3] / cp[nonzero_index])
+    if cp[3] < 0:
+        second_clipped[nonzero_index] = -(second_clipped[nonzero_index] - 1)
+    second_clipped = _permute_list(second_clipped, index_permutation)
+    assert check(second_clipped)
+
+    second_retained = list(zeros)
+    zero_indices = [idx for idx in range(3) if idx != nonzero_index]
+    second_retained[zero_indices[0]] = 3
+    second_retained[zero_indices[1]] = 2
+    second_retained[nonzero_index] = -ceil((cp[3] - 3 * cp[zero_indices[0]] - 2 * cp[zero_indices[1]]) / cp[nonzero_index])
+    second_retained = _permute_list(second_retained, index_permutation)
+    assert not check(second_retained)
+
+
+@pytest.mark.parametrize("index_permutation,cut_depth,cut_tilt,cut_rotation",
+                         product([None, [1, 0, 2], [1, 2, 0], [2, 0, 1]],
+                                 [0.2, 0.5, 0.7],
+                                 [0.5, 1, 1.25],
+                                 [0.75, 1.1, 1.3]))
+def test_cut_plane_check_advanced(index_permutation, cut_depth, cut_tilt, cut_rotation):
+    viewer_state = Vispy3DVolumeViewerState()
+    viewer_state.cut_enabled = True
+    viewer_state.cut_depth = cut_depth
+    viewer_state.resolution = 128
+    viewer_state.cut_mode = "Advanced"
+    viewer_state.cut_rotation = cut_rotation
+    viewer_state.cut_tilt = cut_tilt
+
+    bounds = xyz_bounds(viewer_state, with_resolution=True)
+
+    index_permutation = index_permutation or [1, 2, 0]
+
+    cp = cutting_plane_from_state(viewer_state)
+    assert cp is not None
+
+    check = create_cut_plane_check(viewer_state, bounds)
+    first_clipped = _permute_list([0.0, 0.0, -ceil((cp[3] - 1) / cp[2])], index_permutation)
+    assert check(first_clipped)
+
+    first_retained = [0.0, -ceil(2 * cp[3] / cp[1]), 0.0]
+    if cp[3] < 0:
+        first_retained[1] *= -1
+    first_retained = _permute_list(first_retained, index_permutation)
+    assert not check(first_retained)
+
+    second_clipped = [0.0, 0.0, ceil(cp[3] / cp[2])]
+    if cp[3] < 0:
+        second_clipped[2] = -(second_clipped[2] - 1)
+    second_clipped = _permute_list(second_clipped, index_permutation)
+    assert check(second_clipped)
+
+    second_retained = [-ceil((1 + cp[3] - 3 * cp[1] - 2 * cp[2]) / cp[0]), 3.0, 2.0]
+    if cp[0] > 0:
+        second_retained[0] *= -1
+    second_retained = _permute_list(second_retained, index_permutation)
+    assert not check(second_retained)
+
+
+@pytest.mark.parametrize("index_permutation,cut_enabled",
+                         product([None, [1,2,0], [2,0,1]], [True, False]))
+def test_cut_plane_check_type(index_permutation, cut_enabled):
+    viewer_state = Vispy3DVolumeViewerState()
+    viewer_state.cut_enabled = cut_enabled
+    viewer_state.cut_depth = 0.5 
+    viewer_state.resolution = 128
+    bounds = xyz_bounds(viewer_state, with_resolution=True)
+
+    check = create_cut_plane_check(viewer_state, bounds, index_permutation=index_permutation)
+    assert callable(check)
+    signature = inspect.signature(check)
+    assert signature.return_annotation is bool
+    assert "indices" in signature.parameters
+    assert signature.parameters["indices"] is int
+
+
+@pytest.mark.parametrize("index_permutation",
+                         [None, [1,2,0], [2,0,1]])
+def test_cut_plane_check_empty_plane_always_true(index_permutation):
+    viewer_state = Vispy3DVolumeViewerState()
+    viewer_state.cut_enabled = False
+    viewer_state.resolution = 128
+    bounds = xyz_bounds(viewer_state, with_resolution=True)
+
+    check = create_cut_plane_check(viewer_state, bounds, index_permutation=index_permutation)
+    assert check([1, 2, 3])
+    assert check([2, 4, 7])
+    assert check([0, 1, 2])
+    assert check([128, 129, 130])
+
+
+def test_apply_cut_plane_to_isosurface():
+    viewer_state = Vispy3DVolumeViewerState()
+    viewer_state.cut_enabled = True
+    viewer_state.cut_depth = 0.5
+    viewer_state.resolution = 128
+    viewer_state.cut_mode = "Simple"
+    viewer_state.cut_axis = "X"
+
+    bounds = xyz_bounds(viewer_state, with_resolution=True)
+    points = [
+        # Retained
+        [10.1, 17.2, 11.0],
+        [62.1, 12.7, 24.7],
+        [34.7, 19.6, 22.7],
+        [92.4, 86.6, 22.7],
+        # Clipped
+        [54.1, 34.6, 102.1],
+        [11.1, 67.5, 87.6],
+        [16.2, 101.7, 76.5],
+    ]
+
+    triangles = [
+        # Completely retained
+        [0, 1, 2],
+        [0, 1, 3],
+        [1, 2, 3],
+        # One point retained
+        [2, 4, 5],
+        [2, 4, 6],
+        # Two points retained
+        [0, 1, 4],
+        [2, 3, 6],
+        # Completely clipped
+        [4, 5, 6],
+    ]
+
+    new_points, new_triangles = apply_cut_plane_to_isosurface(viewer_state, bounds, points, triangles)
+
+    # (4 retained points)
+    # + (2 new points from triangles 3 & 4)
+    # + (2 new points each from triangles 4 & 5)
+    assert len(new_points) == 4 + 2 + 2 * 2
+
+    # 7 retained triangles
+    # + 1 new triangle each from triangles 5 & 6
+    assert len(new_triangles) == 7 + 2

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from math import ceil
 
-from numpy import isfinite, argwhere, transpose
+from numpy import apply_along_axis, isfinite, argwhere, fromfunction, transpose
 from typing import Iterable, List, Optional, Union
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
@@ -71,7 +71,16 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
         isorange = isomax - isomin
         nonempty_indices = argwhere(data > isomin)
-
+        cut_plane = None
+        if getattr(viewer_state, "cut_enabled", False):
+            from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
+            cut_plane = cutting_plane_from_state(viewer_state)
+            if cut_plane is not None:
+                resolution_factors = [256 / bound[2] for bound in bounds]
+                cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
+                def cut_plane_index_check(indices):
+                    return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0
+            
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
 
@@ -80,7 +89,10 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
             voxel_colors = [[int(256 * float(c)) for c in vc[:3]] for vc in voxel_colors]
 
         for indices in nonempty_indices:
-            value = data[tuple(indices)]
+            index_tuple = tuple(indices)
+            if cut_plane is not None and cut_plane_index_check(index_tuple):
+                continue
+            value = data[index_tuple]
             t_voxel = (value - isomin) / isorange
             if t_voxel > 0 and hasattr(layer_state, 'stretch'):
                 t_voxel = layer_state.stretch_object([t_voxel], **layer_state.stretch_parameters)[0]

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -71,16 +71,13 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
         isorange = isomax - isomin
         nonempty_indices = argwhere(data > isomin)
-        cut_plane = None
-        if getattr(viewer_state, "cut_enabled", False):
-            from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
-            cut_plane = cutting_plane_from_state(viewer_state)
-            if cut_plane is not None:
-                resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
-                cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
-                def cut_plane_index_check(indices):
-                    return cut_plane_coeffs[1] * indices[0] + cut_plane_coeffs[2] * indices[1] + cut_plane_coeffs[0] * indices[2] + cut_plane[3] > 0
-            
+        using_cut_plane = getattr(viewer_state, "cut_enabled", False)
+        if using_cut_plane:
+            from glue_ar.common.cut_plane import create_cut_plane_check
+            cut_plane_check = create_cut_plane_check(viewer_state, bounds)
+        else:
+            cut_plane_check = lambda _p: True
+
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
 
@@ -90,7 +87,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
         for indices in nonempty_indices:
             index_tuple = tuple(indices)
-            if cut_plane is not None and cut_plane_index_check(index_tuple):
+            if using_cut_plane and cut_plane_check(index_tuple):
                 continue
             value = data[index_tuple]
             t_voxel = (value - isomin) / isorange
@@ -294,15 +291,12 @@ def add_voxel_layers_usd(builder: USDBuilder,
 
         isorange = isomax - isomin
         nonempty_indices = argwhere(data - isomin > 0)
-        cut_plane = None
-        if getattr(viewer_state, "cut_enabled", False):
-            from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
-            cut_plane = cutting_plane_from_state(viewer_state)
-            if cut_plane is not None:
-                resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
-                cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
-                def cut_plane_index_check(indices):
-                    return cut_plane_coeffs[1] * indices[0] + cut_plane_coeffs[2] * indices[1] + cut_plane_coeffs[0] * indices[2] + cut_plane[3] > 0
+        using_cut_plane = getattr(viewer_state, "cut_enabled", False)
+        if using_cut_plane:
+            from glue_ar.common.cut_plane import create_cut_plane_check
+            cut_plane_check = create_cut_plane_check(viewer_state, bounds)
+        else:
+            cut_plane_check = lambda _p: True
 
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
@@ -313,7 +307,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
 
         for indices in nonempty_indices:
             index_tuple = tuple(indices)
-            if cut_plane is not None and cut_plane_index_check(index_tuple):
+            if using_cut_plane and cut_plane_check(index_tuple):
                 continue
             value = data[index_tuple]
             t_voxel = (value - isomin) / isorange

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -79,7 +79,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
                 resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
                 cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
                 def cut_plane_index_check(indices):
-                    return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0
+                    return cut_plane_coeffs[1] * indices[0] + cut_plane_coeffs[2] * indices[1] + cut_plane_coeffs[0] * indices[2] + cut_plane[3] > 0
             
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
@@ -302,7 +302,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
                 resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
                 cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
                 def cut_plane_index_check(indices):
-                    return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0
+                    return cut_plane_coeffs[1] * indices[0] + cut_plane_coeffs[2] * indices[1] + cut_plane_coeffs[0] * indices[2] + cut_plane[3] > 0
 
         color = layer_color(layer_state)
         color_components = hex_to_components(color)

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -294,6 +294,15 @@ def add_voxel_layers_usd(builder: USDBuilder,
 
         isorange = isomax - isomin
         nonempty_indices = argwhere(data - isomin > 0)
+        cut_plane = None
+        if getattr(viewer_state, "cut_enabled", False):
+            from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
+            cut_plane = cutting_plane_from_state(viewer_state)
+            if cut_plane is not None:
+                resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
+                cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
+                def cut_plane_index_check(indices):
+                    return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0
 
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
@@ -303,8 +312,10 @@ def add_voxel_layers_usd(builder: USDBuilder,
             voxel_colors = [[int(256 * float(c)) for c in vc[:3]] for vc in voxel_colors]
 
         for indices in nonempty_indices:
-
-            value = data[tuple(indices)]
+            index_tuple = tuple(indices)
+            if cut_plane is not None and cut_plane_index_check(index_tuple):
+                continue
+            value = data[index_tuple]
             t_voxel = (value - isomin) / isorange
             if t_voxel > 0 and hasattr(layer_state, 'stretch'):
                 t_voxel = layer_state.stretch_object([t_voxel], **layer_state.stretch_parameters)[0]

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -53,6 +53,13 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
     occupied_voxels = {}
 
+    using_cut_plane = getattr(viewer_state, "cut_enabled", False)
+    if using_cut_plane:
+        from glue_ar.common.cut_plane import create_cut_plane_check
+        cut_plane_check = create_cut_plane_check(viewer_state, bounds)
+    else:
+        cut_plane_check = lambda _p: True
+
     for layer_state, option in zip(layer_states, options):
         opacity_cutoff = clamp(option.opacity_cutoff, 0, 1)
         cmap_resolution = clamp(option.cmap_resolution, 0, 1)
@@ -71,12 +78,6 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
         isorange = isomax - isomin
         nonempty_indices = argwhere(data > isomin)
-        using_cut_plane = getattr(viewer_state, "cut_enabled", False)
-        if using_cut_plane:
-            from glue_ar.common.cut_plane import create_cut_plane_check
-            cut_plane_check = create_cut_plane_check(viewer_state, bounds)
-        else:
-            cut_plane_check = lambda _p: True
 
         color = layer_color(layer_state)
         color_components = hex_to_components(color)
@@ -274,6 +275,13 @@ def add_voxel_layers_usd(builder: USDBuilder,
     occupied_voxels = {}
     colors_map = defaultdict(set)
 
+    using_cut_plane = getattr(viewer_state, "cut_enabled", False)
+    if using_cut_plane:
+        from glue_ar.common.cut_plane import create_cut_plane_check
+        cut_plane_check = create_cut_plane_check(viewer_state, bounds)
+    else:
+        cut_plane_check = lambda _p: True
+
     for layer_state, option in zip(layer_states, options):
         opacity_cutoff = clamp(option.opacity_cutoff, 0, 1)
         cmap_resolution = clamp(option.cmap_resolution, 0, 1)
@@ -291,12 +299,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
 
         isorange = isomax - isomin
         nonempty_indices = argwhere(data - isomin > 0)
-        using_cut_plane = getattr(viewer_state, "cut_enabled", False)
-        if using_cut_plane:
-            from glue_ar.common.cut_plane import create_cut_plane_check
-            cut_plane_check = create_cut_plane_check(viewer_state, bounds)
-        else:
-            cut_plane_check = lambda _p: True
+
 
         color = layer_color(layer_state)
         color_components = hex_to_components(color)

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from math import ceil
 
-from numpy import apply_along_axis, isfinite, argwhere, fromfunction, transpose
+from numpy import isfinite, argwhere, transpose
 from typing import Iterable, List, Optional, Union
 
 from glue.viewers.volume3d.viewer_state import VolumeViewerState3D

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -76,7 +76,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
             from glue_vispy_viewers.volume.viewer_state import cutting_plane_from_state
             cut_plane = cutting_plane_from_state(viewer_state)
             if cut_plane is not None:
-                resolution_factors = [256 / bound[2] for bound in bounds]
+                resolution_factors = [viewer_state.resolution / bound[2] for bound in bounds]
                 cut_plane_coeffs = [factor * coeff for factor, coeff in zip(resolution_factors, cut_plane[:3])]
                 def cut_plane_index_check(indices):
                     return cut_plane_coeffs[0] * indices[0] + cut_plane_coeffs[1] * indices[1] + cut_plane_coeffs[2] * indices[2] + cut_plane[3] < 0

--- a/glue_ar/common/voxels.py
+++ b/glue_ar/common/voxels.py
@@ -58,7 +58,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
         from glue_ar.common.cut_plane import create_cut_plane_check
         cut_plane_check = create_cut_plane_check(viewer_state, bounds)
     else:
-        cut_plane_check = lambda _p: True
+        cut_plane_check = None
 
     for layer_state, option in zip(layer_states, options):
         opacity_cutoff = clamp(option.opacity_cutoff, 0, 1)
@@ -88,7 +88,7 @@ def add_voxel_layers_gltf(builder: GLTFBuilder,
 
         for indices in nonempty_indices:
             index_tuple = tuple(indices)
-            if using_cut_plane and cut_plane_check(index_tuple):
+            if using_cut_plane and cut_plane_check and cut_plane_check(index_tuple):
                 continue
             value = data[index_tuple]
             t_voxel = (value - isomin) / isorange
@@ -280,7 +280,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
         from glue_ar.common.cut_plane import create_cut_plane_check
         cut_plane_check = create_cut_plane_check(viewer_state, bounds)
     else:
-        cut_plane_check = lambda _p: True
+        cut_plane_check = None
 
     for layer_state, option in zip(layer_states, options):
         opacity_cutoff = clamp(option.opacity_cutoff, 0, 1)
@@ -310,7 +310,7 @@ def add_voxel_layers_usd(builder: USDBuilder,
 
         for indices in nonempty_indices:
             index_tuple = tuple(indices)
-            if using_cut_plane and cut_plane_check(index_tuple):
+            if using_cut_plane and cut_plane_check and cut_plane_check(index_tuple):
                 continue
             value = data[index_tuple]
             t_voxel = (value - isomin) / isorange

--- a/glue_ar/qt/tests/test_tool_volume.py
+++ b/glue_ar/qt/tests/test_tool_volume.py
@@ -65,14 +65,16 @@ class TestVolumeExportTool:
         tool = toolbar.tools["save"]
         assert len([subtool for subtool in tool.subtools if isinstance(subtool, QtARExportTool)]) == 1
 
-    @pytest.mark.parametrize("extension,compression",
+    @pytest.mark.parametrize("extension,compression,cut_enabled",
                              product(("glB", "glTF", "USDA", "USDC", "USDZ", "STL"),
-                                     compression_options))
-    def test_tool_export_call(self, extension, compression):
+                                     compression_options, [True, False]))
+    def test_tool_export_call(self, extension, compression, cut_enabled):
         auto_accept = dialog_auto_accept_with_options(filetype=extension, compression=compression)
         with patch("qtpy.compat.getsavefilename") as fd, \
              patch.object(QtARExportDialog, "exec_", auto_accept), \
              patch.object(QtARExportTool, "_start_worker") as start_worker:
+
+            self.viewer.state.cut_enabled = cut_enabled
 
             ext = extension.lower()
             filepath = f"test.{ext}"

--- a/glue_ar/utils.py
+++ b/glue_ar/utils.py
@@ -367,5 +367,15 @@ def binned_opacity(raw_opacity: float, resolution: float) -> float:
 def offset_triangles(triangle_indices, offset):
     return [tuple(idx + offset for idx in triangle) for triangle in triangle_indices]
 
+
 def instance_attribute(instance, attribute, fallback):
     return attribute if hasattr(instance, attribute) else fallback
+
+
+def is_bit_set(value: int, bit: int):
+    return value & (2**bit) > 0
+
+
+def set_bit_on(value: int, bit: int):
+    return value | (2**bit)
+        


### PR DESCRIPTION
This is built on top of #153 and adds cutting plane support for our isosurface exports.

The isosurface exports are built using marching cubes, so the idea here is to run the cutting plane check on each vertex of the generated mesh and keep only the ones on the right side of the plane. We then drop any triangles where all of the vertices have been clipped.

We could get something that would probably work fine almost all of the time by just only keeping triangles where all three vertices are retained, but I wanted to avoid the possibility of any strange edge cases, so what this PR does is to update the triangulation to include the unclipped portions of any triangles that cross the cutting plane. To be more precise:
* If a triangle has one unclipped vertex, we add two new vertices where the edges from this vertex cross the cutting plane, and replace the existing triangle with a new one formed by the unclipped vertex and the two intersection points.
* If a triangle has two unclipped vertices, we find the intersection points as in the previous case. However, in this case the unclipped portion of the triangle is a quadrilateral, so we split it into two separate triangles whose orientation respect that of the original triangle.
